### PR TITLE
refactor: streamline Hive instance handling in OpBase and Transfer classes to make sure memo keys are available without having to pass them around endlessly

### DIFF
--- a/src/v4vapp_backend_v2/hive_models/op_base.py
+++ b/src/v4vapp_backend_v2/hive_models/op_base.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 from enum import StrEnum, auto
 from typing import Any, ClassVar, Dict, List
 
+from nectar import Hive
 from pydantic import BaseModel, Field, computed_field
 
 from v4vapp_backend_v2.helpers.crypto_conversion import CryptoConversion
@@ -184,6 +185,7 @@ class OpBase(BaseModel):
     op_tracked: ClassVar[List[str]] = OP_TRACKED
     watch_users: ClassVar[List[str]] = []
     last_quote: ClassVar[QuoteResponse] = QuoteResponse()
+    hive_inst: ClassVar[Hive] = None
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/src/v4vapp_backend_v2/hive_models/op_transfer.py
+++ b/src/v4vapp_backend_v2/hive_models/op_transfer.py
@@ -1,11 +1,11 @@
 from datetime import datetime
-from typing import Any, ClassVar
+from typing import Any
 
 from nectar import Hive
 from pydantic import ConfigDict, Field
 
-from v4vapp_backend_v2.helpers.crypto_conversion import CryptoConv, CryptoConversion
-from v4vapp_backend_v2.helpers.crypto_prices import AllQuotes, QuoteResponse
+from v4vapp_backend_v2.helpers.crypto_conversion import CryptoConv
+from v4vapp_backend_v2.helpers.crypto_prices import AllQuotes
 from v4vapp_backend_v2.helpers.general_purpose_funcs import seconds_only_time_diff
 from v4vapp_backend_v2.hive.hive_extras import decode_memo
 from v4vapp_backend_v2.hive_models.account_name_type import AccNameType
@@ -84,16 +84,15 @@ class Transfer(TransferRaw):
     model_config = ConfigDict(populate_by_name=True)
     # Defined as a CLASS VARIABLE outside the
 
-
     def __init__(self, **hive_event: Any) -> None:
         super().__init__(**hive_event)
-        hive_inst: Hive | None = hive_event.get("hive_inst", None)
+        hive_inst: Hive = hive_event.get("hive_inst", OpBase.hive_inst)
         self.post_process(hive_inst=hive_inst)
         if self.last_quote.get_age() > 600.0:
             self.update_quote_sync(AllQuotes().get_binance_quote())
         self.update_conv()
 
-    def post_process(self, hive_inst: Hive | None = None) -> None:
+    def post_process(self, hive_inst: Hive) -> None:
         if self.memo.startswith("#") and hive_inst:
             self.d_memo = decode_memo(memo=self.memo, hive_inst=hive_inst)
         else:

--- a/src/v4vapp_backend_v2/hive_models/stream_ops.py
+++ b/src/v4vapp_backend_v2/hive_models/stream_ops.py
@@ -10,7 +10,7 @@ from v4vapp_backend_v2.helpers.async_wrapper import sync_to_async_iterable
 from v4vapp_backend_v2.hive.hive_extras import get_blockchain_instance, get_hive_client
 from v4vapp_backend_v2.hive_models.custom_json_data import custom_json_test_data
 from v4vapp_backend_v2.hive_models.op_all import OpAny, op_any_or_base
-from v4vapp_backend_v2.hive_models.op_base import OP_TRACKED, op_realm
+from v4vapp_backend_v2.hive_models.op_base import OP_TRACKED, OpBase, op_realm
 from v4vapp_backend_v2.hive_models.op_base_counters import OpInTrxCounter
 
 
@@ -57,6 +57,8 @@ async def stream_ops_async(
     """
     hive = hive or get_hive_client()
     blockchain = get_blockchain_instance(hive_instance=hive)
+    # This ensures the Transaction class has a hive instance with memo keys
+    OpBase.hive_inst = hive
 
     if opNames:
         op_realms = [op_realm(op) for op in opNames]

--- a/tests/hive_models/test_op_transfer.py
+++ b/tests/hive_models/test_op_transfer.py
@@ -76,9 +76,10 @@ def test_model_validate_transfer_enhanced():
     if not HIVE_MEMO_TEST_KEY:
         pytest.skip("HIVE_MEMO_TEST_KEY is not available in environment variables")
     hive_inst = get_hive_client(keys=[HIVE_MEMO_TEST_KEY])
+    OpBase.hive_inst = hive_inst
     for hive_event in load_hive_events(op_type=OpTypes.TRANSFER):
         if hive_event["type"] == "transfer":
-            hive_event["hive_inst"] = hive_inst
+            # hive_event["hive_inst"] = hive_inst
             transfer = Transfer.model_validate(hive_event)
             assert transfer.trx_id == hive_event["trx_id"]
             assert transfer.amount.amount == hive_event["amount"]["amount"]


### PR DESCRIPTION
Signed-off-by: Brian of London (home imac) <brian@v4v.app>