### PR TITLE
Fixing Hive HBD send issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "v4vapp-backend-v2"
-version = "2.0.0"
+version = "2.0.1"
 description = "Back End for the V4V.app bridge from Hive to Lightning"
 authors = [{name = "Brian of London (home imac)", email = "brian@v4v.app"}]
 license = {text = "MIT"}

--- a/src/v4vapp_backend_v2/conversion/keepsats_to_hive.py
+++ b/src/v4vapp_backend_v2/conversion/keepsats_to_hive.py
@@ -121,7 +121,14 @@ async def conversion_keepsats_to_hive(
         fixed_hive_quote = tracked_op.fixed_quote
         if fixed_hive_quote:
             quote = fixed_hive_quote.quote_response
-            conv_result = fixed_hive_quote.conversion_result
+            # Need to recalc the conversion based on the stored quote, this keeps the Hive/HBD currency to receive correct.
+            conv_result = await calc_keepsats_to_hive(
+                timestamp=tracked_op.timestamp,
+                msats=msats,
+                amount=amount,
+                quote=quote,
+                to_currency=to_currency,
+            )
 
     try:
         if not conv_result:

--- a/tests/helpers/test_crypto_prices.py
+++ b/tests/helpers/test_crypto_prices.py
@@ -412,6 +412,19 @@ def test_quote_response_fetch_date():
     assert quote.age_p > 1742126888  # 55 years in seconds back to Jan 1 1970
 
 
+def test_quote_response_parses_iso_string_fetch_date():
+    """Ensure QuoteResponse accepts ISO string fetch_date (from JSON/cache) and
+    that `age`/`age_p` work without raising TypeError.
+    """
+    now = datetime.now(tz=timezone.utc)
+    iso = now.isoformat()
+    q = QuoteResponse.model_validate({"fetch_date": iso})
+    assert isinstance(q.fetch_date, datetime)
+    assert q.fetch_date.tzinfo is not None
+    # age should be non-negative (very recent)
+    assert q.age_p >= 0
+
+
 async def fetch_all_quote_json_files():
     """
     Fetches all quote data and writes them to JSON files.

--- a/uv.lock
+++ b/uv.lock
@@ -3655,7 +3655,7 @@ wheels = [
 
 [[package]]
 name = "v4vapp-backend-v2"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
This pull request focuses on improving the handling and normalization of datetime fields (especially ISO-8601 strings) throughout the codebase to ensure robust and consistent processing of cached and serialized data. It also introduces better logging for fixed quote creation and validation, and includes a minor version bump.

**Datetime normalization and robustness:**

* Added a centralized `_parse_iso_datetime` helper in `crypto_prices.py` to robustly parse ISO-8601 strings and ensure all datetime fields are timezone-aware, defaulting to epoch on invalid input. This function is now used throughout the codebase for all datetime normalization.
* Updated `QuoteResponse` model and related methods to use `_parse_iso_datetime` for `fetch_date`, ensuring consistent handling of datetimes from various sources (e.g., cache, JSON, naive datetimes). This prevents TypeErrors and ensures computed fields like `age` work reliably. [[1]](diffhunk://#diff-047717671a587e05f3945dc3202a3e924d916c276c3d424a443743b2a9bb2426R223-R240) [[2]](diffhunk://#diff-047717671a587e05f3945dc3202a3e924d916c276c3d424a443743b2a9bb2426L211-R262) [[3]](diffhunk://#diff-047717671a587e05f3945dc3202a3e924d916c276c3d424a443743b2a9bb2426L311-R373) [[4]](diffhunk://#diff-047717671a587e05f3945dc3202a3e924d916c276c3d424a443743b2a9bb2426L597-R649) [[5]](diffhunk://#diff-047717671a587e05f3945dc3202a3e924d916c276c3d424a443743b2a9bb2426L616-R667)
* Added a new test to verify that `QuoteResponse` correctly parses ISO string `fetch_date` fields and that age calculations remain robust.

**Logging and reliability improvements:**

* Enhanced logging in `fixed_quote_class.py` to provide more detailed information when creating and validating fixed quotes, aiding in debugging and monitoring. [[1]](diffhunk://#diff-87e6a5f7471abb584f329334789bf0a9fa397b9ca4f2782475b440f55f49bfceR124-R135) [[2]](diffhunk://#diff-87e6a5f7471abb584f329334789bf0a9fa397b9ca4f2782475b440f55f49bfceR158-R161)
* Improved cache TTL logic for fixed quotes to better handle short-lived and normal cache times, aligning with test expectations.

**Other changes:**

* Minor documentation and type annotation improvements for clarity and accuracy.
* Version bump from `2.0.0` to `2.0.1` in `pyproject.toml`.