### PR TITLE
fix: update cust_id for exchange transactions to use exchange name instead of hive account name

### DIFF
--- a/src/v4vapp_backend_v2/config/setup.py
+++ b/src/v4vapp_backend_v2/config/setup.py
@@ -660,10 +660,10 @@ class HiveConfig(BaseConfig):
     @property
     def all_account_names(self) -> List[str]:
         """
-        Retrieve the names of all accounts. All names must be set in order to receive any.
+        Retrieve the names of all significant accounts. All names must be set in order to receive any.
 
         Returns:
-            List[str]: A list containing the names of all accounts.
+            List[str]: A list containing the names of all significant accounts.
         """
         if (
             self.server_account

--- a/src/v4vapp_backend_v2/process/process_hive.py
+++ b/src/v4vapp_backend_v2/process/process_hive.py
@@ -276,6 +276,7 @@ async def process_transfer_op(
     ):
         # Use the configured exchange adapter name as the Exchange Holdings sub-account
         exchange_sub = get_exchange_adapter().exchange_name
+        ledger_entry.cust_id = exchange_sub
         ledger_entry.debit = AssetAccount(name="Exchange Holdings", sub=exchange_sub)
         ledger_entry.credit = AssetAccount(name="Treasury Hive", sub=treasury_account)
         ledger_entry.description = f"Treasury to Exchange transfer: {base_description}"
@@ -286,6 +287,7 @@ async def process_transfer_op(
         and hive_transfer.to_account == exchange_account
     ):
         exchange_sub = get_exchange_adapter().exchange_name
+        ledger_entry.cust_id = exchange_sub
         ledger_entry.debit = AssetAccount(name="Exchange Holdings", sub=exchange_sub)
         ledger_entry.credit = AssetAccount(name="Customer Deposits Hive", sub=server_account)
         ledger_entry.description = f"Server to Exchange transfer: {base_description}"
@@ -295,8 +297,10 @@ async def process_transfer_op(
         hive_transfer.from_account in exchange_accounts
         and hive_transfer.to_account == treasury_account
     ):
-        ledger_entry.debit = AssetAccount(name="Treasury Hive", sub=exchange_account)
-        ledger_entry.credit = AssetAccount(name="Exchange Deposits Hive", sub=treasury_account)
+        exchange_sub = get_exchange_adapter().exchange_name
+        ledger_entry.cust_id = exchange_sub
+        ledger_entry.debit = AssetAccount(name="Treasury Hive", sub=treasury_account)
+        ledger_entry.credit = AssetAccount(name="Exchange Holdings", sub=exchange_sub)
         ledger_entry.description = f"Exchange to Treasury transfer: {base_description}"
         ledger_entry.user_memo = lightning_memo(hive_transfer.user_memo)
         ledger_entry.ledger_type = LedgerType.EXCHANGE_TO_TREASURY


### PR DESCRIPTION
Signed-off-by: Brian of London (home imac) <brian@v4v.app>