### PR TITLE
Update version to 2.7.7 and improve async operations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "v4vapp-backend-v2"
-version = "2.7.6"
+version = "2.7.7"
 description = "Back End for the V4V.app bridge from Hive to Lightning"
 authors = [{name = "Brian of London (home imac)", email = "brian@v4v.app"}]
 license = {text = "MIT"}

--- a/src/v4vapp_backend_v2/admin/admin_app.py
+++ b/src/v4vapp_backend_v2/admin/admin_app.py
@@ -310,7 +310,7 @@ class AdminApp:
                 return JSONResponse(
                     {
                         "success": True,
-                        "message": f"Archive process completed, deleted {count} entries",
+                        "message": f"Archive process completed, moved {count} entries",
                     }
                 )
             except Exception as e:

--- a/src/v4vapp_backend_v2/process/hold_release_keepsats.py
+++ b/src/v4vapp_backend_v2/process/hold_release_keepsats.py
@@ -242,8 +242,9 @@ async def archive_old_hold_release_keepsats_entries(
         )
         return 0
     try:
-        cursor = from_collection.aggregate(pipeline=pipeline)
-        cursor.close()
+        cursor = await from_collection.aggregate(pipeline=pipeline)
+        await cursor.to_list(length=None)
+        await cursor.close()
     except Exception as e:
         logger.error(
             f"Error during archiving process: {e}",

--- a/src/v4vapp_backend_v2/process/hold_release_keepsats.py
+++ b/src/v4vapp_backend_v2/process/hold_release_keepsats.py
@@ -1,4 +1,4 @@
-import asyncio
+import inspect
 from datetime import datetime, timedelta, timezone
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any, Mapping, Sequence
@@ -204,6 +204,7 @@ async def archive_old_hold_release_keepsats_entries(
         if not reverse_archive
         else LedgerEntry.collection_name()
     )
+
     pipeline: Sequence[Mapping[str, Any]] = [
         {"$match": match_filter},
         {
@@ -242,9 +243,13 @@ async def archive_old_hold_release_keepsats_entries(
         )
         return 0
     try:
-        cursor = await from_collection.aggregate(pipeline=pipeline)
+        agg = from_collection.aggregate(pipeline=pipeline)
+        cursor = await agg if inspect.isawaitable(agg) else agg
         await cursor.to_list(length=None)
-        await cursor.close()
+        if hasattr(cursor, "close"):
+            close_result = cursor.close()
+            if inspect.isawaitable(close_result):
+                await close_result
     except Exception as e:
         logger.error(
             f"Error during archiving process: {e}",
@@ -259,12 +264,11 @@ async def archive_old_hold_release_keepsats_entries(
     # Now delete the original entries after archiving
     if not reverse_archive:
         try:
-            logger.warning("Not Deleting anything.")
-            # delete_result = await from_collection.delete_many(match_filter)
-            # logger.info(
-            #     f"NOT Deleted {delete_result.deleted_count} original Reversed, HOLD_KEEPSATS or RELEASE_KEEPSATS entries after archiving.",
-            #     extra={"notification": False},
-            # )
+            delete_result = await from_collection.delete_many(match_filter)
+            logger.info(
+                f"Moved {delete_result.deleted_count} original Reversed, HOLD_KEEPSATS or RELEASE_KEEPSATS entries after archiving.",
+                extra={"notification": False},
+            )
         except Exception as e:
             logger.error(
                 f"Error during deletion of original entries after archiving: {e}",

--- a/src/v4vapp_backend_v2/process/hold_release_keepsats.py
+++ b/src/v4vapp_backend_v2/process/hold_release_keepsats.py
@@ -259,11 +259,12 @@ async def archive_old_hold_release_keepsats_entries(
     # Now delete the original entries after archiving
     if not reverse_archive:
         try:
-            delete_result = await from_collection.delete_many(match_filter)
-            logger.info(
-                f"Deleted {delete_result.deleted_count} original Reversed, HOLD_KEEPSATS or RELEASE_KEEPSATS entries after archiving.",
-                extra={"notification": False},
-            )
+            logger.warning("Not Deleting anything.")
+            # delete_result = await from_collection.delete_many(match_filter)
+            # logger.info(
+            #     f"NOT Deleted {delete_result.deleted_count} original Reversed, HOLD_KEEPSATS or RELEASE_KEEPSATS entries after archiving.",
+            #     extra={"notification": False},
+            # )
         except Exception as e:
             logger.error(
                 f"Error during deletion of original entries after archiving: {e}",

--- a/tests/process/test_archive_ledger_entries.py
+++ b/tests/process/test_archive_ledger_entries.py
@@ -53,6 +53,7 @@ def _make_mock_collection(total_count: int = 0, ledger_type_count: int = 0) -> M
     # aggregate returns a cursor-like object; close() is synchronous in the current
     # implementation (called without await).
     cursor = MagicMock()
+    cursor.to_list = AsyncMock(return_value=[])
     cursor.close = MagicMock()
     col.aggregate = MagicMock(return_value=cursor)
 
@@ -142,9 +143,7 @@ async def test_reverse_archive_no_delete():
     # Verify aggregate was called once and the pipeline targets the main ledger
     mock_archived_col.aggregate.assert_called_once()
     call_kwargs = mock_archived_col.aggregate.call_args.kwargs
-    pipeline_arg = (
-        call_kwargs.get("pipeline") or mock_archived_col.aggregate.call_args.args[0]
-    )
+    pipeline_arg = call_kwargs.get("pipeline") or mock_archived_col.aggregate.call_args.args[0]
     merge_stages = [stage for stage in pipeline_arg if "$merge" in stage]
     assert len(merge_stages) == 1
     assert merge_stages[0]["$merge"]["into"] == LedgerEntry.collection_name()

--- a/uv.lock
+++ b/uv.lock
@@ -3714,7 +3714,7 @@ wheels = [
 
 [[package]]
 name = "v4vapp-backend-v2"
-version = "2.7.6"
+version = "2.7.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
Enhance the `archive_old_hold_release_keepsats_entries` function by implementing async cursor operations and update the version to 2.7.7 in relevant files. Deletion logic has been modified to prevent accidental deletions.