### PR TITLE
Implement delete_all_ledger_checkpoints function with tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "v4vapp-backend-v2"
-version = "2.7.10"
+version = "2.7.11"
 description = "Back End for the V4V.app bridge from Hive to Lightning"
 authors = [{name = "Brian of London (home imac)", email = "brian@v4v.app"}]
 license = {text = "MIT"}

--- a/src/v4vapp_backend_v2/accounting/ledger_checkpoints.py
+++ b/src/v4vapp_backend_v2/accounting/ledger_checkpoints.py
@@ -29,10 +29,8 @@ Each document covers one account × one period:
 from __future__ import annotations
 
 import asyncio
-import calendar
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
-from enum import StrEnum
 from timeit import default_timer as timer
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -48,14 +46,13 @@ from v4vapp_backend_v2.accounting.account_balances import (
 from v4vapp_backend_v2.accounting.ledger_account_classes import LedgerAccount
 from v4vapp_backend_v2.accounting.ledger_entry_class import LedgerEntry
 from v4vapp_backend_v2.config.setup import InternalConfig, logger
+from v4vapp_backend_v2.helpers.period_end_type import (
+    PeriodType,
+    completed_period_ends_since,
+    last_completed_period_end,
+)
 
 ICON = "📌"
-
-
-class PeriodType(StrEnum):
-    DAILY = "daily"
-    WEEKLY = "weekly"
-    MONTHLY = "monthly"
 
 
 class CheckpointConvSummary(BaseModel):
@@ -252,17 +249,17 @@ async def delete_all_ledger_checkpoints(
 
     """
     try:
-        await LedgerCheckpoint.collection().delete_many(
+        delete_result = await LedgerCheckpoint.collection().delete_many(
             filter={
                 "account_name": account_name,
                 "account_sub": account_sub,
                 "account_type": account_type,
-                "period_type": str(period_type.value),
+                "period_type": str(period_type),
             }
         )
         logger.debug(
             f"📌 Checkpoint deleted: {account_name}:{account_sub} {period_type}",
-            extra={"notification": False},
+            extra={"notification": False, "delete_result": delete_result.raw_result},
         )
     except Exception as e:
         logger.error(
@@ -273,106 +270,57 @@ async def delete_all_ledger_checkpoints(
 
 
 # ---------------------------------------------------------------------------
-# Period boundary helpers
-# ---------------------------------------------------------------------------
-
-
-def period_end_for_date(period_type: PeriodType, d: date) -> datetime:
-    """Return the last microsecond of the calendar period that contains *d*.
-
-    The returned datetime is timezone-aware (UTC) and represents the inclusive
-    upper bound: all transactions with ``timestamp ≤ period_end`` belong to
-    this period's checkpoint.
-    """
-    if period_type == PeriodType.DAILY:
-        return datetime(d.year, d.month, d.day, 23, 59, 59, 999999, tzinfo=timezone.utc)
-
-    if period_type == PeriodType.WEEKLY:
-        # ISO week: Monday=0 … Sunday=6; advance to Sunday
-        days_to_sunday = 6 - d.weekday()
-        sunday = d + timedelta(days=days_to_sunday)
-        return datetime(
-            sunday.year, sunday.month, sunday.day, 23, 59, 59, 999999, tzinfo=timezone.utc
-        )
-
-    if period_type == PeriodType.MONTHLY:
-        last_day = calendar.monthrange(d.year, d.month)[1]
-        return datetime(d.year, d.month, last_day, 23, 59, 59, 999999, tzinfo=timezone.utc)
-
-    raise ValueError(f"Unknown period type: {period_type}")
-
-
-def last_completed_period_end(period_type: PeriodType, now: datetime | None = None) -> datetime:
-    """Return the end datetime of the last fully completed period before *now*.
-
-    Unlike :func:`period_end_for_date`, which returns the end of the period
-    *containing* a given date (which may be in the future), this function
-    always returns a period boundary that has already passed:
-
-    - **daily**  → end of yesterday
-    - **weekly** → end of the most-recently completed ISO week (last Sunday)
-    - **monthly** → end of the previous calendar month
-    """
-    if now is None:
-        now = datetime.now(tz=timezone.utc)
-    today = now.date()
-
-    if period_type == PeriodType.DAILY:
-        d = today - timedelta(days=1)
-    elif period_type == PeriodType.WEEKLY:
-        # weekday(): Mon=0 … Sun=6; go back enough days to land on the last Sunday
-        days_since_last_sunday = today.weekday() + 1  # Mon→1, Tue→2, …, Sun→7
-        d = today - timedelta(days=days_since_last_sunday)
-    elif period_type == PeriodType.MONTHLY:
-        # First day of this month minus one day = last day of previous month
-        d = date(today.year, today.month, 1) - timedelta(days=1)
-    else:
-        raise ValueError(f"Unknown period type: {period_type}")
-
-    return period_end_for_date(period_type, d)
-
-
-def completed_period_ends_since(
-    period_type: PeriodType,
-    since: datetime,
-    until: datetime,
-) -> List[datetime]:
-    """Return a list of completed period-end timestamps in chronological order.
-
-    Only periods whose ``period_end`` is strictly less than *until* are
-    included, so the caller's "current" period is never returned as complete.
-
-    Args:
-        period_type: Granularity of the periods to enumerate.
-        since: Start of the range (inclusive).
-        until: End of the range (exclusive).  Typically *now*.
-    """
-    results: List[datetime] = []
-    current = since.date()
-    while True:
-        end = period_end_for_date(period_type, current)
-        if end >= until:
-            break
-        if end > since:
-            results.append(end)
-
-        # Advance to the next period start
-        if period_type == PeriodType.DAILY:
-            current = current + timedelta(days=1)
-        elif period_type == PeriodType.WEEKLY:
-            days_to_next_monday = 7 - current.weekday()
-            current = current + timedelta(days=days_to_next_monday)
-        elif period_type == PeriodType.MONTHLY:
-            last_day = calendar.monthrange(current.year, current.month)[1]
-            first_next = date(current.year, current.month, last_day) + timedelta(days=1)
-            current = first_next
-
-    return results
-
-
-# ---------------------------------------------------------------------------
 # CRUD helpers
 # ---------------------------------------------------------------------------
+
+
+async def invalidate_checkpoints_for_accounts_by_date(
+    accounts: List[LedgerAccount], timestamp: datetime
+) -> None:
+    """
+    Invalidate the cache for given accounts and timestamp.
+
+    This is necessary after reversing a transaction or making a backdated correction (such as for the
+    Customer Deposits Hive (Asset) account for the server when reversing Limit Order Create transactions).
+
+    Args:
+        - *accounts*: List of LedgerAccount instances identifying the accounts
+        - *timestamp*: The timestamp to compare against the last completed period end
+    """
+    tasks = []
+    # convert timestamp to UTC if it is naive
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    for period_type in PeriodType:
+        if timestamp < last_completed_period_end(period_type):
+            tasks.append(delete_checkpoints_for_accounts_and_period_type(accounts, period_type))
+    await asyncio.gather(*tasks)
+
+
+async def delete_checkpoints_for_accounts_and_period_type(
+    accounts: List[LedgerAccount], period_type: PeriodType
+) -> None:
+    """
+    Delete all checkpoints for given accounts and period type.
+
+    This is necessary after reversing a transaction or making a backdated correction (such as for the
+    Customer Deposits Hive (Asset) account for the server when reversing Limit Order Create transactions).
+
+    Args:
+        - *accounts*: List of LedgerAccount instances identifying the accounts
+        - *period_type*: Granularity of the checkpoints to delete (daily/weekly/monthly)
+    """
+    tasks = []
+    for account in accounts:
+        tasks.append(
+            delete_all_ledger_checkpoints(
+                account_name=account.name,
+                account_sub=account.sub,
+                account_type=str(account.account_type),
+                period_type=period_type,
+            )
+        )
+    await asyncio.gather(*tasks)
 
 
 async def get_latest_checkpoint_before(

--- a/src/v4vapp_backend_v2/accounting/ledger_checkpoints.py
+++ b/src/v4vapp_backend_v2/accounting/ledger_checkpoints.py
@@ -45,7 +45,7 @@ from v4vapp_backend_v2.accounting.account_balances import (
     list_all_active_accounts,
     one_account_balance,
 )
-from v4vapp_backend_v2.accounting.ledger_account_classes import LedgerAccount, LiabilityAccount
+from v4vapp_backend_v2.accounting.ledger_account_classes import LedgerAccount
 from v4vapp_backend_v2.accounting.ledger_entry_class import LedgerEntry
 from v4vapp_backend_v2.config.setup import InternalConfig, logger
 
@@ -233,6 +233,43 @@ class LedgerCheckpoint(BaseModel):
                 extra={"notification": False},
             )
             raise
+
+
+async def delete_all_ledger_checkpoints(
+    account_name: str, account_sub: str, account_type: str, period_type: PeriodType
+) -> None:
+    """
+    Delete all the checkpoint documents for a given account and period type from MongoDB.
+    This is necessary after reversing a transaction or making a backdated correction (such as for the
+    Customer Deposits Hive (Asset) account for the server when reversing Limit Order Create transactions).
+
+    Args:
+        - *account_name*: Name of the ledger account (e.g. "VSC Liability")
+        - *account_sub*: Sub-account identifier (e.g. "alice")
+        - *account_type*: AccountType enum value as a string (e.g. "Liability")
+        - *period_type*: Granularity of the checkpoints to delete (daily/weekly/monthly)
+
+
+    """
+    try:
+        await LedgerCheckpoint.collection().delete_many(
+            filter={
+                "account_name": account_name,
+                "account_sub": account_sub,
+                "account_type": account_type,
+                "period_type": str(period_type.value),
+            }
+        )
+        logger.debug(
+            f"📌 Checkpoint deleted: {account_name}:{account_sub} {period_type}",
+            extra={"notification": False},
+        )
+    except Exception as e:
+        logger.error(
+            f"Failed to delete checkpoint: {e}",
+            extra={"notification": False},
+        )
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
+++ b/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
@@ -744,9 +744,6 @@ class LedgerEntry(BaseModel):
 
         """
         self.db_checks()
-        await (
-            self._invalidate_cache()
-        )  # Invalidate cache before saving to ensure any reads during save are consistent
         if reverse:
             self.set_reversed()
         try:
@@ -772,6 +769,11 @@ class LedgerEntry(BaseModel):
                 f"\n{self}",
                 extra={"notification": False, "db_ans": ans, **self.log_extra},
             )
+            # Invalidate cache AFTER the DB write so any subsequent cache miss
+            # re-reads the DB with the new entry already committed. Invalidating
+            # before the write creates a race: another coroutine can repopulate
+            # the cache from DB (missing the new entry) before insert_one completes.
+            await self._invalidate_cache()
             return ans
         except DuplicateKeyError as e:
             if not ignore_duplicates:

--- a/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
+++ b/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
@@ -744,14 +744,6 @@ class LedgerEntry(BaseModel):
 
         """
         self.db_checks()
-        from v4vapp_backend_v2.accounting.ledger_checkpoints import (
-            invalidate_checkpoints_for_accounts_by_date,
-        )
-
-        await invalidate_checkpoints_for_accounts_by_date(
-            accounts=[self.debit, self.credit], timestamp=self.timestamp
-        )
-
         if reverse:
             self.set_reversed()
             logger.info(
@@ -786,6 +778,13 @@ class LedgerEntry(BaseModel):
             # before the write creates a race: another coroutine can repopulate
             # the cache from DB (missing the new entry) before insert_one completes.
             await self._invalidate_cache()
+            from v4vapp_backend_v2.accounting.ledger_checkpoints import (
+                invalidate_checkpoints_for_accounts_by_date,
+            )
+
+            await invalidate_checkpoints_for_accounts_by_date(
+                accounts=[self.debit, self.credit], timestamp=self.timestamp
+            )
             return ans
         except DuplicateKeyError as e:
             if not ignore_duplicates:

--- a/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
+++ b/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
@@ -1,5 +1,5 @@
 import textwrap
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
 from math import isclose
 from typing import Any, Dict, List, Mapping, Self, Sequence
@@ -747,30 +747,19 @@ class LedgerEntry(BaseModel):
         await (
             self._invalidate_cache()
         )  # Invalidate cache before saving to ensure any reads during save are consistent
+        from v4vapp_backend_v2.accounting.ledger_checkpoints import (
+            invalidate_checkpoints_for_accounts_by_date,
+        )
+        await invalidate_checkpoints_for_accounts_by_date(
+            accounts=[self.debit, self.credit], timestamp=self.timestamp
+        )
+
         if reverse:
             self.set_reversed()
-            # This is necessary when reversing because it will invalidate earlier cached items
-            if self.timestamp < datetime.now(tz=timezone.utc) - timedelta(minutes=5):
-                logger.info(
-                    f"Ledger entry is being reversed {self.short_id} {self.group_id} but is older than 5 minutes",
-                    extra={"notification": True, **self.log_extra},
-                )
-                from v4vapp_backend_v2.accounting.ledger_checkpoints import (
-                    PeriodType,
-                    delete_all_ledger_checkpoints,
-                )
-                await delete_all_ledger_checkpoints(
-                    account_name=self.debit.name,
-                    account_sub=self.debit.sub,
-                    account_type=self.debit.account_type,
-                    period_type=PeriodType.DAILY,
-                )
-                await delete_all_ledger_checkpoints(
-                    account_name=self.credit.name,
-                    account_sub=self.credit.sub,
-                    account_type=self.credit.account_type,
-                    period_type=PeriodType.DAILY,
-                )
+            logger.info(
+                f"Ledger entry is being reversed {self.short_id} {self.group_id}",
+                extra={"notification": True, **self.log_extra},
+            )
         try:
             # Get the model dump and convert Decimal objects to strings for MongoDB compatibility
             document: Any = self.model_dump(by_alias=True, exclude_none=True, exclude_unset=True)

--- a/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
+++ b/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
@@ -1,5 +1,5 @@
 import textwrap
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from math import isclose
 from typing import Any, Dict, List, Mapping, Self, Sequence
@@ -749,6 +749,28 @@ class LedgerEntry(BaseModel):
         )  # Invalidate cache before saving to ensure any reads during save are consistent
         if reverse:
             self.set_reversed()
+            # This is necessary when reversing because it will invalidate earlier cached items
+            if self.timestamp < datetime.now(tz=timezone.utc) - timedelta(minutes=5):
+                logger.info(
+                    f"Ledger entry is being reversed {self.short_id} {self.group_id} but is older than 5 minutes",
+                    extra={"notification": True, **self.log_extra},
+                )
+                from v4vapp_backend_v2.accounting.ledger_checkpoints import (
+                    PeriodType,
+                    delete_all_ledger_checkpoints,
+                )
+                await delete_all_ledger_checkpoints(
+                    account_name=self.debit.name,
+                    account_sub=self.debit.sub,
+                    account_type=self.debit.account_type,
+                    period_type=PeriodType.DAILY,
+                )
+                await delete_all_ledger_checkpoints(
+                    account_name=self.credit.name,
+                    account_sub=self.credit.sub,
+                    account_type=self.credit.account_type,
+                    period_type=PeriodType.DAILY,
+                )
         try:
             # Get the model dump and convert Decimal objects to strings for MongoDB compatibility
             document: Any = self.model_dump(by_alias=True, exclude_none=True, exclude_unset=True)

--- a/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
+++ b/src/v4vapp_backend_v2/accounting/ledger_entry_class.py
@@ -744,12 +744,10 @@ class LedgerEntry(BaseModel):
 
         """
         self.db_checks()
-        await (
-            self._invalidate_cache()
-        )  # Invalidate cache before saving to ensure any reads during save are consistent
         from v4vapp_backend_v2.accounting.ledger_checkpoints import (
             invalidate_checkpoints_for_accounts_by_date,
         )
+
         await invalidate_checkpoints_for_accounts_by_date(
             accounts=[self.debit, self.credit], timestamp=self.timestamp
         )

--- a/src/v4vapp_backend_v2/helpers/period_end_type.py
+++ b/src/v4vapp_backend_v2/helpers/period_end_type.py
@@ -1,0 +1,108 @@
+import calendar
+from datetime import date, datetime, timedelta, timezone
+from enum import StrEnum
+from typing import List
+
+
+class PeriodType(StrEnum):
+    DAILY = "daily"
+    WEEKLY = "weekly"
+    MONTHLY = "monthly"
+
+
+# ---------------------------------------------------------------------------
+# Period boundary helpers
+# ---------------------------------------------------------------------------
+
+
+def period_end_for_date(period_type: PeriodType, d: date) -> datetime:
+    """Return the last microsecond of the calendar period that contains *d*.
+
+    The returned datetime is timezone-aware (UTC) and represents the inclusive
+    upper bound: all transactions with ``timestamp ≤ period_end`` belong to
+    this period's checkpoint.
+    """
+    if period_type == PeriodType.DAILY:
+        return datetime(d.year, d.month, d.day, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+    if period_type == PeriodType.WEEKLY:
+        # ISO week: Monday=0 … Sunday=6; advance to Sunday
+        days_to_sunday = 6 - d.weekday()
+        sunday = d + timedelta(days=days_to_sunday)
+        return datetime(
+            sunday.year, sunday.month, sunday.day, 23, 59, 59, 999999, tzinfo=timezone.utc
+        )
+
+    if period_type == PeriodType.MONTHLY:
+        last_day = calendar.monthrange(d.year, d.month)[1]
+        return datetime(d.year, d.month, last_day, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+    raise ValueError(f"Unknown period type: {period_type}")
+
+
+def last_completed_period_end(period_type: PeriodType, now: datetime | None = None) -> datetime:
+    """Return the end datetime of the last fully completed period before *now*.
+
+    Unlike :func:`period_end_for_date`, which returns the end of the period
+    *containing* a given date (which may be in the future), this function
+    always returns a period boundary that has already passed:
+
+    - **daily**  → end of yesterday
+    - **weekly** → end of the most-recently completed ISO week (last Sunday)
+    - **monthly** → end of the previous calendar month
+    """
+    if now is None:
+        now = datetime.now(tz=timezone.utc)
+    today = now.date()
+
+    if period_type == PeriodType.DAILY:
+        d = today - timedelta(days=1)
+    elif period_type == PeriodType.WEEKLY:
+        # weekday(): Mon=0 … Sun=6; go back enough days to land on the last Sunday
+        days_since_last_sunday = today.weekday() + 1  # Mon→1, Tue→2, …, Sun→7
+        d = today - timedelta(days=days_since_last_sunday)
+    elif period_type == PeriodType.MONTHLY:
+        # First day of this month minus one day = last day of previous month
+        d = date(today.year, today.month, 1) - timedelta(days=1)
+    else:
+        raise ValueError(f"Unknown period type: {period_type}")
+
+    return period_end_for_date(period_type, d)
+
+
+def completed_period_ends_since(
+    period_type: PeriodType,
+    since: datetime,
+    until: datetime,
+) -> List[datetime]:
+    """Return a list of completed period-end timestamps in chronological order.
+
+    Only periods whose ``period_end`` is strictly less than *until* are
+    included, so the caller's "current" period is never returned as complete.
+
+    Args:
+        period_type: Granularity of the periods to enumerate.
+        since: Start of the range (inclusive).
+        until: End of the range (exclusive).  Typically *now*.
+    """
+    results: List[datetime] = []
+    current = since.date()
+    while True:
+        end = period_end_for_date(period_type, current)
+        if end >= until:
+            break
+        if end > since:
+            results.append(end)
+
+        # Advance to the next period start
+        if period_type == PeriodType.DAILY:
+            current = current + timedelta(days=1)
+        elif period_type == PeriodType.WEEKLY:
+            days_to_next_monday = 7 - current.weekday()
+            current = current + timedelta(days=days_to_next_monday)
+        elif period_type == PeriodType.MONTHLY:
+            last_day = calendar.monthrange(current.year, current.month)[1]
+            first_next = date(current.year, current.month, last_day) + timedelta(days=1)
+            current = first_next
+
+    return results

--- a/src/v4vapp_backend_v2/process/hive_notification.py
+++ b/src/v4vapp_backend_v2/process/hive_notification.py
@@ -166,9 +166,17 @@ async def reply_with_hive(details: HiveReturnDetails, nobroadcast: bool = False)
     ):
         reply_type = ReplyType.TRANSFER
         trx = {}
-        adjusted_amount = await check_for_outstanding_hive_balance(
-            cust_id=details.pay_to_cust_id, amount=amount
-        )
+        # For CONVERSION actions the CONV_CUSTOMER ledger entry has already been
+        # written with the exact amount owed. Applying the outstanding-balance
+        # check can incorrectly truncate the payout if the VSC Liability HIVE
+        # balance is stale (cache timing) or has accumulated a discrepancy from
+        # prior truncated payouts.  Skip it for conversions.
+        if details.action == ReturnAction.CONVERSION:
+            adjusted_amount = amount
+        else:
+            adjusted_amount = await check_for_outstanding_hive_balance(
+                cust_id=details.pay_to_cust_id, amount=amount
+            )
         try:
             trx = await send_transfer(
                 hive_client=hive_client,

--- a/tests/accounting/test_account_balances.py
+++ b/tests/accounting/test_account_balances.py
@@ -7,6 +7,8 @@ from pprint import pprint
 import pytest
 from bson import json_util
 
+from unittest.mock import AsyncMock
+
 from v4vapp_backend_v2.accounting.account_balance_pipelines import (
     all_account_balances_pipeline,
     list_all_active_accounts_pipeline,
@@ -56,6 +58,13 @@ async def set_base_config_path_combined(module_monkeypatch):
         test_config_logging_path,
     )
     module_monkeypatch.setattr("v4vapp_backend_v2.config.setup.InternalConfig._instance", None)
+    
+    # Patch delete_checkpoints_for_accounts_and_period_type to do nothing
+    module_monkeypatch.setattr(
+        "v4vapp_backend_v2.accounting.ledger_checkpoints.delete_checkpoints_for_accounts_and_period_type",
+        AsyncMock(),
+    )
+    
     i_c = InternalConfig()
     print("InternalConfig initialized:", i_c)
     db_conn = DBConn()

--- a/tests/accounting/test_ledger_checkpoints.py
+++ b/tests/accounting/test_ledger_checkpoints.py
@@ -24,18 +24,20 @@ from v4vapp_backend_v2.accounting.ledger_account_classes import LiabilityAccount
 from v4vapp_backend_v2.accounting.ledger_checkpoints import (
     CheckpointConvSummary,
     LedgerCheckpoint,
-    PeriodType,
     build_checkpoints_for_period,
-    completed_period_ends_since,
     create_checkpoint,
     delete_all_ledger_checkpoints,
     get_latest_checkpoint_before,
-    last_completed_period_end,
-    period_end_for_date,
 )
 from v4vapp_backend_v2.accounting.ledger_entry_class import LedgerEntry
 from v4vapp_backend_v2.config.setup import InternalConfig
 from v4vapp_backend_v2.database.db_pymongo import DBConn
+from v4vapp_backend_v2.helpers.period_end_type import (
+    PeriodType,
+    completed_period_ends_since,
+    last_completed_period_end,
+    period_end_for_date,
+)
 
 # ---------------------------------------------------------------------------
 # Module-scoped fixtures (DB + test data)

--- a/tests/accounting/test_ledger_checkpoints.py
+++ b/tests/accounting/test_ledger_checkpoints.py
@@ -28,6 +28,7 @@ from v4vapp_backend_v2.accounting.ledger_checkpoints import (
     build_checkpoints_for_period,
     completed_period_ends_since,
     create_checkpoint,
+    delete_all_ledger_checkpoints,
     get_latest_checkpoint_before,
     last_completed_period_end,
     period_end_for_date,
@@ -356,3 +357,245 @@ async def test_build_checkpoints_for_period():
     # At least one checkpoint per account (there may be 0 if test data precedes this range)
     docs_count = await InternalConfig.db["ledger_checkpoints"].count_documents({})
     assert docs_count == count
+
+
+# ---------------------------------------------------------------------------
+# Tests for delete_all function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_all_removes_checkpoints_for_period():
+    """delete_all should remove all checkpoints for a specific account and period type."""
+    # Create multiple checkpoints for different periods
+    period_end_daily = datetime(2025, 1, 31, 23, 59, 59, 999999, tzinfo=timezone.utc)
+    period_end_weekly = datetime(2025, 2, 2, 23, 59, 59, 999999, tzinfo=timezone.utc)
+    period_end_monthly = datetime(2025, 3, 31, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+    # Create checkpoints for the same account with different period types
+    cp_daily = LedgerCheckpoint(
+        account_name="Test Account",
+        account_sub="user123",
+        account_type="Liability",
+        contra=False,
+        period_type=PeriodType.DAILY,
+        period_end=period_end_daily,
+        balances_net={"MSATS": Decimal("10000")},
+    )
+    await cp_daily.save()
+
+    cp_weekly = LedgerCheckpoint(
+        account_name="Test Account",
+        account_sub="user123",
+        account_type="Liability",
+        contra=False,
+        period_type=PeriodType.WEEKLY,
+        period_end=period_end_weekly,
+        balances_net={"MSATS": Decimal("20000")},
+    )
+    await cp_weekly.save()
+
+    cp_monthly = LedgerCheckpoint(
+        account_name="Test Account",
+        account_sub="user123",
+        account_type="Liability",
+        contra=False,
+        period_type=PeriodType.MONTHLY,
+        period_end=period_end_monthly,
+        balances_net={"MSATS": Decimal("30000")},
+    )
+    await cp_monthly.save()
+
+    # Verify checkpoints exist
+    count_before = await LedgerCheckpoint.collection().count_documents(
+        {
+            "account_name": "Test Account",
+            "account_sub": "user123",
+            "account_type": "Liability",
+        }
+    )
+    assert count_before == 3, "Should have created 3 checkpoints"
+
+    # Delete only daily checkpoints
+    await delete_all_ledger_checkpoints("Test Account", "user123", "Liability", PeriodType.DAILY)
+
+    # Verify only daily checkpoints are deleted
+    count_after = await LedgerCheckpoint.collection().count_documents(
+        {
+            "account_name": "Test Account",
+            "account_sub": "user123",
+            "account_type": "Liability",
+        }
+    )
+    assert count_after == 2, "Should have 2 remaining checkpoints after deleting daily ones"
+
+    # Verify weekly and monthly checkpoints still exist
+    remaining = (
+        await LedgerCheckpoint.collection()
+        .find(
+            {
+                "account_name": "Test Account",
+                "account_sub": "user123",
+                "account_type": "Liability",
+            }
+        )
+        .to_list(length=None)
+    )
+
+    period_types = [doc["period_type"] for doc in remaining]
+    assert "weekly" in period_types, "Weekly checkpoint should still exist"
+    assert "monthly" in period_types, "Monthly checkpoint should still exist"
+    assert "daily" not in period_types, "Daily checkpoint should be deleted"
+
+
+@pytest.mark.asyncio
+async def test_delete_all_does_not_affect_other_accounts():
+    """delete_all should only delete checkpoints for the specified account."""
+    period_end = datetime(2025, 1, 31, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+    # Create checkpoints for two different accounts
+    cp1 = LedgerCheckpoint(
+        account_name="Account A",
+        account_sub="user1",
+        account_type="Liability",
+        contra=False,
+        period_type=PeriodType.DAILY,
+        period_end=period_end,
+        balances_net={"MSATS": Decimal("10000")},
+    )
+    await cp1.save()
+
+    cp2 = LedgerCheckpoint(
+        account_name="Account B",
+        account_sub="user1",
+        account_type="Liability",
+        contra=False,
+        period_type=PeriodType.DAILY,
+        period_end=period_end,
+        balances_net={"MSATS": Decimal("20000")},
+    )
+    await cp2.save()
+
+    # Delete checkpoints for Account A
+    await delete_all_ledger_checkpoints("Account A", "user1", "Liability", PeriodType.DAILY)
+
+    # Verify Account A checkpoints are deleted
+    count_a = await LedgerCheckpoint.collection().count_documents(
+        {"account_name": "Account A", "account_sub": "user1"}
+    )
+    assert count_a == 0, "Account A checkpoints should be deleted"
+
+    # Verify Account B checkpoints still exist
+    count_b = await LedgerCheckpoint.collection().count_documents(
+        {"account_name": "Account B", "account_sub": "user1"}
+    )
+    assert count_b == 1, "Account B checkpoints should still exist"
+
+
+@pytest.mark.asyncio
+async def test_delete_all_does_not_affect_different_subs():
+    """delete_all should only delete checkpoints for the specified sub-account."""
+    period_end = datetime(2025, 1, 31, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+    # Create checkpoints for the same account but different subs
+    cp1 = LedgerCheckpoint(
+        account_name="Shared Account",
+        account_sub="user_a",
+        account_type="Liability",
+        contra=False,
+        period_type=PeriodType.DAILY,
+        period_end=period_end,
+        balances_net={"MSATS": Decimal("10000")},
+    )
+    await cp1.save()
+
+    cp2 = LedgerCheckpoint(
+        account_name="Shared Account",
+        account_sub="user_b",
+        account_type="Liability",
+        contra=False,
+        period_type=PeriodType.DAILY,
+        period_end=period_end,
+        balances_net={"MSATS": Decimal("20000")},
+    )
+    await cp2.save()
+
+    # Delete checkpoints for user_a
+    await delete_all_ledger_checkpoints("Shared Account", "user_a", "Liability", PeriodType.DAILY)
+
+    # Verify user_a checkpoints are deleted
+    count_a = await LedgerCheckpoint.collection().count_documents(
+        {"account_name": "Shared Account", "account_sub": "user_a"}
+    )
+    assert count_a == 0, "user_a checkpoints should be deleted"
+
+    # Verify user_b checkpoints still exist
+    count_b = await LedgerCheckpoint.collection().count_documents(
+        {"account_name": "Shared Account", "account_sub": "user_b"}
+    )
+    assert count_b == 1, "user_b checkpoints should still exist"
+
+
+@pytest.mark.asyncio
+async def test_delete_all_with_no_matching_checkpoints():
+    """delete_all should handle gracefully when no matching checkpoints exist."""
+    # Call delete_all for a non-existent account
+    await delete_all_ledger_checkpoints(
+        "NonExistent Account", "nonexistent_sub", "Liability", PeriodType.DAILY
+    )
+
+    # This should not raise an error; just complete successfully
+    count = await LedgerCheckpoint.collection().count_documents(
+        {
+            "account_name": "NonExistent Account",
+            "account_sub": "nonexistent_sub",
+        }
+    )
+    assert count == 0, "No checkpoints should exist for non-existent account"
+
+
+@pytest.mark.asyncio
+async def test_delete_all_deletes_all_matching_checkpoints():
+    """delete_all should delete all checkpoints matching the filter criteria."""
+    # Create multiple checkpoints with different period_ends for the same account/period
+    account_name = "Deletion Test Account"
+    account_sub = "delete_test_sub"
+    account_type = "Asset"
+
+    for i in range(5):
+        period_end = datetime(2025, 1, i + 1, 23, 59, 59, 999999, tzinfo=timezone.utc)
+        cp = LedgerCheckpoint(
+            account_name=account_name,
+            account_sub=account_sub,
+            account_type=account_type,
+            contra=False,
+            period_type=PeriodType.DAILY,
+            period_end=period_end,
+            balances_net={"MSATS": Decimal(str(10000 * (i + 1)))},
+        )
+        await cp.save()
+
+    # Verify all checkpoint exist
+    count_before = await LedgerCheckpoint.collection().count_documents(
+        {
+            "account_name": account_name,
+            "account_sub": account_sub,
+            "account_type": account_type,
+            "period_type": "daily",
+        }
+    )
+    assert count_before == 5, "Should have created 5 checkpoints"
+
+    # Delete all checkpoints for this account/period combination
+    await delete_all_ledger_checkpoints(account_name, account_sub, account_type, PeriodType.DAILY)
+
+    # Verify all checkpoints are deleted
+    count_after = await LedgerCheckpoint.collection().count_documents(
+        {
+            "account_name": account_name,
+            "account_sub": account_sub,
+            "account_type": account_type,
+            "period_type": "daily",
+        }
+    )
+    assert count_after == 0, "All checkpoints should be deleted"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -276,6 +276,7 @@ async def clear_database():
         await db["hive_ops"].delete_many({})
         await db["ledger"].delete_many({})
         await db["pending"].delete_many({})
+        await db["ledger_checkpoints"].delete_many({})
     finally:
         # Close the connection properly
         if hasattr(db_conn, "client") and db_conn.client:

--- a/uv.lock
+++ b/uv.lock
@@ -3714,7 +3714,7 @@ wheels = [
 
 [[package]]
 name = "v4vapp-backend-v2"
-version = "2.7.10"
+version = "2.7.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
Introduce a new function to delete all ledger checkpoints for a specified account and period type, ensuring proper cleanup after reversing transactions. Add tests to verify the functionality of this new feature.