### PR TITLE
fix: carry forward checkpoint-only balances when no delta rows exist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "v4vapp-backend-v2"
-version = "2.7.11"
+version = "2.7.12"
 description = "Back End for the V4V.app bridge from Hive to Lightning"
 authors = [{name = "Brian of London (home imac)", email = "brian@v4v.app"}]
 license = {text = "MIT"}

--- a/src/v4vapp_backend_v2/accounting/account_balances.py
+++ b/src/v4vapp_backend_v2/accounting/account_balances.py
@@ -464,11 +464,13 @@ async def one_account_balance(
         # that currency.
         if checkpoint is not None:
             for unit_str, cp_net in checkpoint.balances_net.items():
-                if unit_str in merged_balances or cp_net == Decimal(0):
+                if cp_net == Decimal(0):
                     continue
                 try:
                     currency = Currency(unit_str)
                 except ValueError:
+                    continue
+                if currency in merged_balances:
                     continue
                 cp_conv_raw = checkpoint.conv_totals.get(unit_str)
                 cp_conv = (
@@ -813,7 +815,7 @@ async def account_balance_printout(
     output.append(f"Units: {', '.join(unit.upper() for unit in units)}")
     if opening_balance_carried_forward:
         output.append(
-            f"No new transactions since {period_start.date()} — opening balance carried forward:"
+            f"No new transactions since {period_start} — opening balance carried forward:"
         )
     output.append("-" * max_width)
 
@@ -870,7 +872,11 @@ async def account_balance_printout(
                 and opening_details.balances_net
             ):
                 ob_net = opening_details.balances_net.get(unit, Decimal(0))
-                if ob_net != Decimal(0):
+                if (
+                    ob_net != Decimal(0)
+                    and not (len(all_rows) == 1 and all_rows[0].ledger_type == "ob")
+                    and not (len(all_rows) == 1 and all_rows[0].ledger_type == "ob")
+                ):
                     ob_date_str = period_start.strftime("%Y-%m-%d")  # type: ignore[union-attr]
                     output.append(f"\n=== {ob_date_str} ===")
                     _, _, ob_bal_fmt = _format_amounts_for_display(
@@ -1077,6 +1083,12 @@ async def account_balance_printout_grouped_by_customer(
         ledger_account_details._recompute_summaries()
 
     units = set(ledger_account_details.balances.keys())
+    if opening_details is not None and opening_details.balances_net:
+        units.update(
+            unit
+            for unit, opening_net in opening_details.balances_net.items()
+            if opening_net != Decimal(0)
+        )
     quote = await TrackedBaseModel.update_quote()
 
     as_of_date_printout = as_of_date if as_of_date else datetime.now(tz=timezone.utc)
@@ -1150,7 +1162,9 @@ async def account_balance_printout_grouped_by_customer(
                 and opening_details.balances_net
             ):
                 ob_net = opening_details.balances_net.get(unit, Decimal(0))
-                if ob_net != Decimal(0):
+                if ob_net != Decimal(0) and not (
+                    len(all_rows) == 1 and all_rows[0].ledger_type == "ob"
+                ):
                     ob_date_str = period_start.strftime("%Y-%m-%d")  # type: ignore[union-attr]
                     output.append(f"\n=== {ob_date_str} ===")
                     ob_display = ob_net / conversion_factor if unit.upper() == "MSATS" else ob_net

--- a/src/v4vapp_backend_v2/accounting/account_balances.py
+++ b/src/v4vapp_backend_v2/accounting/account_balances.py
@@ -406,6 +406,8 @@ async def one_account_balance(
                     f"@ {checkpoint.period_end.date()} → delta from {from_date.date()} to {as_of_date.date()}",
                     extra={"notification": False},
                 )
+            else:
+                from_date = None
         except Exception as e:
             logger.info(
                 f"Checkpoint lookup failed for {account.name}:{account.sub}: {e}",
@@ -456,6 +458,48 @@ async def one_account_balance(
                 running_conv = running_conv + ConvertedSummary.from_crypto_conv(row.conv_signed)
                 row.conv_running_total = running_conv
 
+        # Add synthetic checkpoint-only balances for units that have no delta rows.
+        # This happens when a checkpoint carries a non-zero balance in a currency
+        # but the delta query after the checkpoint does not return any rows for
+        # that currency.
+        if checkpoint is not None:
+            for unit_str, cp_net in checkpoint.balances_net.items():
+                if unit_str in merged_balances or cp_net == Decimal(0):
+                    continue
+                try:
+                    currency = Currency(unit_str)
+                except ValueError:
+                    continue
+                cp_conv_raw = checkpoint.conv_totals.get(unit_str)
+                cp_conv = (
+                    cp_conv_raw.to_converted_summary()
+                    if cp_conv_raw is not None
+                    else ConvertedSummary()
+                )
+                from v4vapp_backend_v2.accounting.accounting_classes import AccountBalanceLine
+
+                merged_balances[currency] = [
+                    AccountBalanceLine(
+                        timestamp=checkpoint.period_end,
+                        description=f"Carried Forward (from {checkpoint.period_end.strftime('%Y-%m-%d')})",
+                        unit=unit_str,
+                        amount=abs(cp_net),
+                        amount_signed=cp_net,
+                        amount_running_total=Decimal(0),
+                        conv_signed={
+                            "hive": Decimal(0),
+                            "hbd": Decimal(0),
+                            "usd": Decimal(0),
+                            "sats": Decimal(0),
+                            "msats": Decimal(0),
+                        },
+                        account_type=str(account.account_type),
+                        name=account.name,
+                        sub=account.sub,
+                        contra=account.contra,
+                    )
+                ]
+
         # --- Apply checkpoint offsets to running totals ---
         if checkpoint is not None:
             for unit, rows in merged_balances.items():
@@ -486,7 +530,6 @@ async def one_account_balance(
         for unit_str, net_val in checkpoint.balances_net.items():
             if net_val == Decimal(0):
                 continue
-            from v4vapp_backend_v2.helpers.currency_class import Currency
 
             try:
                 currency = Currency(unit_str)
@@ -732,6 +775,31 @@ async def account_balance_printout(
             for row in rows:
                 row.amount_running_total += opening_net
                 row.conv_running_total = row.conv_running_total + opening_conv
+        ledger_account_details._recompute_summaries()
+
+        # Add synthetic opening balance rows for units that have no current-period rows.
+        for unit, opening_net in opening_details.balances_net.items():
+            if opening_net == Decimal(0) or unit in ledger_account_details.balances:
+                continue
+            opening_conv = opening_details.balances_totals.get(unit, ConvertedSummary())
+            ob_desc = f"Carried Forward (from {period_start.strftime('%Y-%m-%d')})"
+            synthetic_row = AccountBalanceLine(
+                timestamp=period_start,
+                description=ob_desc,
+                unit=str(unit),
+                amount=abs(opening_net),
+                amount_signed=opening_net,
+                amount_running_total=opening_net,
+                conv_signed=CryptoConv(),
+                account_type=str(account.account_type),
+                name=account.name,
+                sub=account.sub,
+                contra=account.contra,
+                side="",
+                ledger_type="ob",
+            )
+            synthetic_row.conv_running_total = opening_conv
+            ledger_account_details.balances[unit] = [synthetic_row]
         ledger_account_details._recompute_summaries()
 
     units = set(ledger_account_details.balances.keys())
@@ -981,6 +1049,31 @@ async def account_balance_printout_grouped_by_customer(
             for row in rows:
                 row.amount_running_total += opening_net
                 row.conv_running_total = row.conv_running_total + opening_conv
+        ledger_account_details._recompute_summaries()
+
+        # Add synthetic opening balance rows for units that have no current-period rows.
+        for unit, opening_net in opening_details.balances_net.items():
+            if opening_net == Decimal(0) or unit in ledger_account_details.balances:
+                continue
+            opening_conv = opening_details.balances_totals.get(unit, ConvertedSummary())
+            ob_desc = f"Carried Forward (from {period_start.strftime('%Y-%m-%d')})"
+            synthetic_row = AccountBalanceLine(
+                timestamp=period_start,
+                description=ob_desc,
+                unit=str(unit),
+                amount=abs(opening_net),
+                amount_signed=opening_net,
+                amount_running_total=opening_net,
+                conv_signed=CryptoConv(),
+                account_type=str(account.account_type),
+                name=account.name,
+                sub=account.sub,
+                contra=account.contra,
+                side="",
+                ledger_type="ob",
+            )
+            synthetic_row.conv_running_total = opening_conv
+            ledger_account_details.balances[unit] = [synthetic_row]
         ledger_account_details._recompute_summaries()
 
     units = set(ledger_account_details.balances.keys())

--- a/src/v4vapp_backend_v2/accounting/ledger_checkpoints.py
+++ b/src/v4vapp_backend_v2/accounting/ledger_checkpoints.py
@@ -398,7 +398,7 @@ async def get_checkpoint_by_id(
 
 async def latest_period_create_checkpoint(
     account: LedgerAccount, period_type: PeriodType = PeriodType.DAILY
-) -> Tuple[LedgerCheckpoint, bool, timedelta, datetime]:
+) -> Tuple[LedgerCheckpoint | None, bool, timedelta, datetime]:
     """
     Create a checkpoint for the most recently completed period if it does not already exist.
 
@@ -418,7 +418,14 @@ async def latest_period_create_checkpoint(
     now = datetime.now(tz=timezone.utc)
     period_start = last_completed_period_end(period_type, now)
     age = now - period_start
-    checkpoint, created = await create_checkpoint(account, period_type, period_start)
+    try:
+        checkpoint, created = await create_checkpoint(account, period_type, period_start)
+    except ValueError as e:
+        logger.warning(
+            f"⚠️  Could not create checkpoint for latest completed {period_type} period: {e}",
+            extra={"notification": False},
+        )
+        return None, False, age, period_start
     return checkpoint, created, age, period_start
 
 
@@ -428,7 +435,7 @@ async def create_checkpoint(
     period_end: datetime,
     use_cache: bool = True,
     force: bool = False,
-) -> Tuple[LedgerCheckpoint, bool]:
+) -> Tuple[LedgerCheckpoint | None, bool]:
     """
     Compute and persist a checkpoint for *account* at *period_end*.
 
@@ -451,6 +458,10 @@ async def create_checkpoint(
 
     """
     start = timer()
+    all_accounts = await list_all_active_accounts()
+    if account not in all_accounts:
+        raise ValueError(f"Account {account} is not active; cannot create checkpoint.")
+
     if not force:
         existing_checkpoint = await get_checkpoint_by_id(account, period_type, period_end)
         if existing_checkpoint is not None:

--- a/src/v4vapp_backend_v2/accounting/ledger_checkpoints.py
+++ b/src/v4vapp_backend_v2/accounting/ledger_checkpoints.py
@@ -435,7 +435,7 @@ async def create_checkpoint(
     period_end: datetime,
     use_cache: bool = True,
     force: bool = False,
-) -> Tuple[LedgerCheckpoint | None, bool]:
+) -> Tuple[LedgerCheckpoint, bool]:
     """
     Compute and persist a checkpoint for *account* at *period_end*.
 
@@ -458,9 +458,9 @@ async def create_checkpoint(
 
     """
     start = timer()
-    all_accounts = await list_all_active_accounts()
-    if account not in all_accounts:
-        raise ValueError(f"Account {account} is not active; cannot create checkpoint.")
+    # all_accounts = await list_all_active_accounts()
+    # if account not in all_accounts:
+    #     raise ValueError(f"Account {account} is not active; cannot create checkpoint.")
 
     if not force:
         existing_checkpoint = await get_checkpoint_by_id(account, period_type, period_end)

--- a/src/v4vapp_backend_v2/accounting/sanity_checks.py
+++ b/src/v4vapp_backend_v2/accounting/sanity_checks.py
@@ -333,6 +333,7 @@ async def server_account_hive_balances(in_progress: InProgressResults) -> Sanity
             )
             raise
 
+
         deposits_details = tasks["deposits_details"].result()
         traded_deposits_details = tasks["traded_deposits_details"].result()
         balances = tasks["balances"].result()

--- a/src/v4vapp_backend_v2/admin/routers/users.py
+++ b/src/v4vapp_backend_v2/admin/routers/users.py
@@ -206,7 +206,7 @@ async def users_page(request: Request):
     nav_items = nav_manager.get_navigation_items("/admin/users")
 
     # Return page with empty data - actual data will be loaded via JavaScript
-    return templates.TemplateResponse(request, 
+    return templates.TemplateResponse(request,
         "users/users.html",
         {
             "request": request,

--- a/src/v4vapp_backend_v2/process/overwatch_flows.py
+++ b/src/v4vapp_backend_v2/process/overwatch_flows.py
@@ -14,6 +14,7 @@ def check_balance_request(event: FlowEvent) -> bool:
     """Return True only when the triggering op is a balance-request transfer."""
     return getattr(event.op, "balance_request", False)
 
+
 # ---------------------------------------------------------------------------
 # Hive-to-Keepsats conversion flow
 # ---------------------------------------------------------------------------
@@ -966,6 +967,63 @@ HIVE_TRANSFER_PAYWITHSATS_FLOW = FlowDefinition(
 
 
 # ---------------------------------------------------------------------------
+# Hive transfer failure (refund) flow
+# ---------------------------------------------------------------------------
+# Flow: User sends HIVE/HBD to the server account, but the system cannot
+# process the request (conversion limits exceeded, amount below minimum,
+# Lightning decode failure, LND payment failure, etc.).  The system returns
+# the full amount to the sender.
+#
+# This flow has the same stage signatures as balance_request, but without
+# the event_filter — it acts as a catch-all for any transfer that ends in
+# an immediate refund.  When balance_request completes first (it has an
+# event_filter), this candidate is resolved via superset/subset logic.
+#
+# Primary events (same short_id as trigger):
+#   1. transfer op (trigger) — customer sends HIVE to server
+#   2. cust_h_in ledger — Customer deposits HIVE
+#
+# Reply events (different short_id — the refund transfer):
+#   3. transfer op — server returns the HIVE
+#   4. cust_h_out ledger — Refund recorded
+# ---------------------------------------------------------------------------
+
+HIVE_TRANSFER_FAILURE_FLOW = FlowDefinition(
+    name="hive_transfer_failure",
+    description="Failed Hive transfer: amount returned to sender (conversion limits, decode failure, etc.)",
+    trigger_op_type="transfer",
+    stages=[
+        # --- Primary stages (same short_id as trigger) ---
+        FlowStage(
+            name="trigger_transfer",
+            event_type="op",
+            op_type="transfer",
+            group="primary",
+        ),
+        FlowStage(
+            name="customer_hive_in",
+            event_type="ledger",
+            ledger_type=LedgerType.CUSTOMER_HIVE_IN,
+            group="primary",
+        ),
+        # --- Refund stages (reply group) ---
+        FlowStage(
+            name="refund_transfer_op",
+            event_type="op",
+            op_type="transfer",
+            group="refund",
+        ),
+        FlowStage(
+            name="customer_hive_out",
+            event_type="ledger",
+            ledger_type=LedgerType.CUSTOMER_HIVE_OUT,
+            group="refund",
+        ),
+    ],
+)
+
+
+# ---------------------------------------------------------------------------
 # Registry of all known flow definitions
 # ---------------------------------------------------------------------------
 
@@ -981,4 +1039,5 @@ FLOW_DEFINITIONS = {
     "keepsats_internal_transfer": KEEPSATS_INTERNAL_TRANSFER_FLOW,
     "hive_transfer_paywithsats": HIVE_TRANSFER_PAYWITHSATS_FLOW,
     "balance_request": BALANCE_REQUEST_FLOW,
+    "hive_transfer_failure": HIVE_TRANSFER_FAILURE_FLOW,
 }

--- a/src/v4vapp_backend_v2/process/process_overwatch.py
+++ b/src/v4vapp_backend_v2/process/process_overwatch.py
@@ -106,6 +106,7 @@ class FlowStage(BaseModel):
         ),
         exclude=True,  # not serialised to Redis — restored from registered definition
     )
+    op_log_str: str = Field("", description="The log string for the operation in this flow stage)")
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -118,6 +119,7 @@ class FlowStage(BaseModel):
         required: bool = True,
         group: str = "primary",
         event_filter: Callable[[FlowEvent], bool] | None = None,
+        op_log_str: str = "",
         **data: Any,
     ) -> None:
         """Explicit initializer helps type checkers.
@@ -135,6 +137,7 @@ class FlowStage(BaseModel):
             required=required,
             group=group,
             event_filter=event_filter,
+            op_log_str=op_log_str,
             **data,
         )
 
@@ -270,8 +273,23 @@ class FlowEvent(BaseModel):
         if self.event_type == "ledger" and self.ledger_entry:
             return self.ledger_entry.log_str
         if self.event_type == "op" and self.op:
-            return self.op.log_str
-        return "UnknownEvent"
+            try:
+                val = getattr(self.op, "log_str", None)
+                if val:
+                    return val
+            except Exception:
+                pass
+        # Fallback: construct a useful string from the event's own fields
+        parts: list[str] = []
+        if self.op_type:
+            parts.append(self.op_type)
+        if self.ledger_type:
+            parts.append(self.ledger_type.value)
+        if self.short_id:
+            parts.append(self.short_id)
+        if self.event_value:
+            parts.append(self.event_value)
+        return " ".join(parts) if parts else "UnknownEvent"
 
 
 class FlowInstance(BaseModel):
@@ -339,6 +357,13 @@ class FlowInstance(BaseModel):
         this signature with defaults makes static analysis happy while still
         delegating to the BaseModel machinery.
         """
+        # Deep-copy the definition so each instance has independent stages
+        # whose op_log_str can be set without mutating the shared template.
+        # When deserialising from Redis (model_validate_json), flow_definition
+        # arrives as a plain dict — Pydantic will create a fresh object from
+        # it, so no copy is needed.
+        if isinstance(flow_definition, FlowDefinition):
+            flow_definition = flow_definition.model_copy(deep=True)
         super().__init__(
             flow_definition=flow_definition,
             trigger_group_id=trigger_group_id,
@@ -367,6 +392,7 @@ class FlowInstance(BaseModel):
         for stage in self.flow_definition.stages:
             if stage.name not in previously_matched and stage.matches(event):
                 # Event matched — record it
+                stage.op_log_str = event.log_str
                 self.events.append(event)
                 if self.status == FlowStatus.PENDING:
                     self.status = FlowStatus.IN_PROGRESS
@@ -609,9 +635,15 @@ class Overwatch:
                 try:
                     flow = FlowInstance.model_validate_json(raw)
                     normalized_rkey = self._redis_flow_key(flow)
-                    # update definition to the currently registered one (if any)
+                    # Restore event_filter callbacks from the registered
+                    # definition (they are not serialised to Redis) while
+                    # preserving per-instance op_log_str values.
                     if flow.flow_definition.name in self._flow_definitions:
-                        flow.flow_definition = self._flow_definitions[flow.flow_definition.name]
+                        registered = self._flow_definitions[flow.flow_definition.name]
+                        for inst_stage, reg_stage in zip(
+                            flow.flow_definition.stages, registered.stages
+                        ):
+                            inst_stage.event_filter = reg_stage.event_filter
                     # if definition change means the flow is now complete, fix status
                     if flow.is_complete and flow.status != FlowStatus.COMPLETED:
                         flow.status = FlowStatus.COMPLETED

--- a/src/v4vapp_backend_v2/process/process_overwatch.py
+++ b/src/v4vapp_backend_v2/process/process_overwatch.py
@@ -106,7 +106,9 @@ class FlowStage(BaseModel):
         ),
         exclude=True,  # not serialised to Redis — restored from registered definition
     )
-    op_log_str: str = Field("", description="The log string for the operation in this flow stage)")
+    event_log_str: str = Field(
+        "", description="The log string captured for this flow stage's matched event"
+    )
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -119,7 +121,7 @@ class FlowStage(BaseModel):
         required: bool = True,
         group: str = "primary",
         event_filter: Callable[[FlowEvent], bool] | None = None,
-        op_log_str: str = "",
+        event_log_str: str = "",
         **data: Any,
     ) -> None:
         """Explicit initializer helps type checkers.
@@ -137,7 +139,7 @@ class FlowStage(BaseModel):
             required=required,
             group=group,
             event_filter=event_filter,
-            op_log_str=op_log_str,
+            event_log_str=event_log_str,
             **data,
         )
 
@@ -358,7 +360,7 @@ class FlowInstance(BaseModel):
         delegating to the BaseModel machinery.
         """
         # Deep-copy the definition so each instance has independent stages
-        # whose op_log_str can be set without mutating the shared template.
+        # whose event_log_str can be set without mutating the shared template.
         # When deserialising from Redis (model_validate_json), flow_definition
         # arrives as a plain dict — Pydantic will create a fresh object from
         # it, so no copy is needed.
@@ -392,7 +394,7 @@ class FlowInstance(BaseModel):
         for stage in self.flow_definition.stages:
             if stage.name not in previously_matched and stage.matches(event):
                 # Event matched — record it
-                stage.op_log_str = event.log_str
+                stage.event_log_str = event.log_str
                 self.events.append(event)
                 if self.status == FlowStatus.PENDING:
                     self.status = FlowStatus.IN_PROGRESS
@@ -637,7 +639,7 @@ class Overwatch:
                     normalized_rkey = self._redis_flow_key(flow)
                     # Restore event_filter callbacks from the registered
                     # definition (they are not serialised to Redis) while
-                    # preserving per-instance op_log_str values.
+                    # preserving per-instance event_log_str values.
                     if flow.flow_definition.name in self._flow_definitions:
                         registered = self._flow_definitions[flow.flow_definition.name]
                         for inst_stage, reg_stage in zip(

--- a/src/v4vapp_backend_v2/process/process_overwatch.py
+++ b/src/v4vapp_backend_v2/process/process_overwatch.py
@@ -637,15 +637,19 @@ class Overwatch:
                 try:
                     flow = FlowInstance.model_validate_json(raw)
                     normalized_rkey = self._redis_flow_key(flow)
-                    # Restore event_filter callbacks from the registered
-                    # definition (they are not serialised to Redis) while
-                    # preserving per-instance event_log_str values.
+                    # Rebuild the flow definition from the current registered
+                    # version (deep copy) so stage additions/reordering are
+                    # picked up.  Per-instance fields (event_log_str) are
+                    # transferred by matching stage name.
                     if flow.flow_definition.name in self._flow_definitions:
                         registered = self._flow_definitions[flow.flow_definition.name]
-                        for inst_stage, reg_stage in zip(
-                            flow.flow_definition.stages, registered.stages
-                        ):
-                            inst_stage.event_filter = reg_stage.event_filter
+                        persisted_by_name = {s.name: s for s in flow.flow_definition.stages}
+                        fresh_def = registered.model_copy(deep=True)
+                        for stage in fresh_def.stages:
+                            persisted = persisted_by_name.get(stage.name)
+                            if persisted is not None:
+                                stage.event_log_str = persisted.event_log_str
+                        flow.flow_definition = fresh_def
                     # if definition change means the flow is now complete, fix status
                     if flow.is_complete and flow.status != FlowStatus.COMPLETED:
                         flow.status = FlowStatus.COMPLETED

--- a/tests/accounting/test_account_balances.py
+++ b/tests/accounting/test_account_balances.py
@@ -3,11 +3,10 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from pprint import pprint
+from unittest.mock import AsyncMock
 
 import pytest
 from bson import json_util
-
-from unittest.mock import AsyncMock
 
 from v4vapp_backend_v2.accounting.account_balance_pipelines import (
     all_account_balances_pipeline,
@@ -58,13 +57,13 @@ async def set_base_config_path_combined(module_monkeypatch):
         test_config_logging_path,
     )
     module_monkeypatch.setattr("v4vapp_backend_v2.config.setup.InternalConfig._instance", None)
-    
+
     # Patch delete_checkpoints_for_accounts_and_period_type to do nothing
     module_monkeypatch.setattr(
         "v4vapp_backend_v2.accounting.ledger_checkpoints.delete_checkpoints_for_accounts_and_period_type",
         AsyncMock(),
     )
-    
+
     i_c = InternalConfig()
     print("InternalConfig initialized:", i_c)
     db_conn = DBConn()
@@ -374,6 +373,86 @@ async def test_get_account_balance_printout():
     accounts = await list_all_accounts()
     for account in accounts[:3]:
         result, details = await account_balance_printout(account)
+
+
+async def test_account_balance_printout_includes_opening_only_currency_rows(monkeypatch):
+    from v4vapp_backend_v2.accounting.accounting_classes import AccountBalanceLine
+    from v4vapp_backend_v2.helpers.crypto_prices import QuoteResponse
+    from v4vapp_backend_v2.helpers.currency_class import Currency
+
+    period_start = datetime(2026, 4, 17, 23, 59, 59, tzinfo=timezone.utc)
+    account = LiabilityAccount(name="VSC Liability", sub="custA")
+
+    current_hive_row = AccountBalanceLine(
+        short_id="hive-current",
+        ledger_type="cust_h_in",
+        timestamp=datetime(2026, 4, 18, 8, 0, 0, tzinfo=timezone.utc),
+        description="HIVE deposit",
+        cust_id="custA",
+        amount=Decimal("100.000"),
+        amount_signed=Decimal("100.000"),
+        unit=Currency.HIVE,
+        side="debit",
+        amount_running_total=Decimal("100.000"),
+    )
+    ledger_account_details = LedgerAccountDetails(
+        name="VSC Liability",
+        account_type=AccountType.LIABILITY,
+        sub="custA",
+        balances={Currency.HIVE: [current_hive_row]},
+    )
+
+    opening_hbd_row = AccountBalanceLine(
+        short_id="hbd-open",
+        ledger_type="ob",
+        timestamp=period_start,
+        description="Opening HBD balance",
+        cust_id="custA",
+        amount=Decimal("1.745"),
+        amount_signed=Decimal("1.745"),
+        unit=Currency.HBD,
+        side="debit",
+        amount_running_total=Decimal("1.745"),
+    )
+    opening_details = LedgerAccountDetails(
+        name="VSC Liability",
+        account_type=AccountType.LIABILITY,
+        sub="custA",
+        balances={Currency.HBD: [opening_hbd_row]},
+    )
+
+    async def fake_one_account_balance(*args, **kwargs):
+        account_arg = kwargs.get("account", args[0] if args else None)
+        as_of_date = kwargs.get("as_of_date")
+        use_cache = kwargs.get("use_cache")
+        assert account_arg == account
+        assert as_of_date == period_start
+        assert use_cache is False
+        return opening_details
+
+    monkeypatch.setattr(
+        "v4vapp_backend_v2.accounting.account_balances.one_account_balance",
+        fake_one_account_balance,
+    )
+
+    result, _ = await account_balance_printout(
+        account,
+        line_items=False,
+        ledger_account_details=ledger_account_details,
+        quote=QuoteResponse(),
+        period_start=period_start,
+    )
+    assert "Unit: HBD" in result
+    assert "Carried Forward (from 2026-04-17)" in result
+
+    result_grouped, _ = await account_balance_printout_grouped_by_customer(
+        account,
+        line_items=False,
+        ledger_account_details=ledger_account_details,
+        period_start=period_start,
+    )
+    assert "Unit: HBD" in result_grouped
+    assert "Carried Forward (from 2026-04-17)" in result_grouped
 
 
 async def test_get_keepsats_balance():

--- a/tests/accounting/test_account_balances.py
+++ b/tests/accounting/test_account_balances.py
@@ -437,22 +437,22 @@ async def test_account_balance_printout_includes_opening_only_currency_rows(monk
 
     result, _ = await account_balance_printout(
         account,
-        line_items=False,
+        line_items=True,
         ledger_account_details=ledger_account_details,
         quote=QuoteResponse(),
         period_start=period_start,
     )
     assert "Unit: HBD" in result
-    assert "Carried Forward (from 2026-04-17)" in result
+    assert result.count("Carried Forward (from 2026-04-17)") == 1
 
     result_grouped, _ = await account_balance_printout_grouped_by_customer(
         account,
-        line_items=False,
+        line_items=True,
         ledger_account_details=ledger_account_details,
         period_start=period_start,
     )
     assert "Unit: HBD" in result_grouped
-    assert "Carried Forward (from 2026-04-17)" in result_grouped
+    assert result_grouped.count("Carried Forward (from 2026-04-17)") == 1
 
 
 async def test_get_keepsats_balance():

--- a/tests/accounting/test_ledger_checkpoints.py
+++ b/tests/accounting/test_ledger_checkpoints.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import pytest
 from bson import json_util
 
-from v4vapp_backend_v2.accounting.account_balances import one_account_balance
+from v4vapp_backend_v2.accounting.account_balances import InProgressResults, one_account_balance
 from v4vapp_backend_v2.accounting.ledger_account_classes import LiabilityAccount
 from v4vapp_backend_v2.accounting.ledger_checkpoints import (
     CheckpointConvSummary,
@@ -32,6 +32,7 @@ from v4vapp_backend_v2.accounting.ledger_checkpoints import (
 from v4vapp_backend_v2.accounting.ledger_entry_class import LedgerEntry
 from v4vapp_backend_v2.config.setup import InternalConfig
 from v4vapp_backend_v2.database.db_pymongo import DBConn
+from v4vapp_backend_v2.helpers.currency_class import Currency
 from v4vapp_backend_v2.helpers.period_end_type import (
     PeriodType,
     completed_period_ends_since,
@@ -343,6 +344,114 @@ async def test_one_account_balance_checkpoint_matches_full_history():
     assert abs(result_with_cp.hive - result_without_cp.hive) <= Decimal("0.001"), (
         f"HIVE mismatch: with_cp={result_with_cp.hive} without={result_without_cp.hive}"
     )
+
+
+@pytest.mark.asyncio
+async def test_one_account_balance_checkpoint_carried_forward_missing_currency(monkeypatch):
+    """one_account_balance must carry forward checkpoint-only currencies when no delta rows exist."""
+    account = LiabilityAccount(name="VSC Liability", sub="testuser")
+    checkpoint = LedgerCheckpoint(
+        account_name=account.name,
+        account_sub=account.sub,
+        account_type=str(account.account_type),
+        contra=account.contra,
+        period_type=PeriodType.DAILY,
+        period_end=datetime(2026, 4, 17, 23, 59, 59, 999999, tzinfo=timezone.utc),
+        balances_net={"hbd": Decimal("1.745")},
+        conv_totals={
+            "hbd": CheckpointConvSummary(
+                hive=Decimal(0),
+                hbd=Decimal("1.745"),
+                usd=Decimal(0),
+                sats=Decimal(0),
+                msats=Decimal(0),
+            )
+        },
+    )
+
+    async def fake_get_latest_checkpoint_before(acc, as_of):
+        assert acc == account
+        return checkpoint
+
+    class FakeCursor:
+        def __init__(self, docs):
+            self.docs = docs
+
+        async def to_list(self, length=None):
+            return self.docs
+
+    class FakeCollection:
+        async def aggregate(self, pipeline):
+            return FakeCursor(
+                [
+                    {
+                        "account_type": "Asset",
+                        "name": "Customer Deposits Hive",
+                        "sub": "devser.v4vapp",
+                        "contra": False,
+                        "balances": {
+                            "hive": [
+                                {
+                                    "group_id": "test",
+                                    "short_id": "test",
+                                    "ledger_type": "cust_h_in",
+                                    "timestamp": datetime(
+                                        2026, 4, 18, 8, 38, 2, tzinfo=timezone.utc
+                                    ),
+                                    "description": "HIVE delta row",
+                                    "user_memo": "",
+                                    "cust_id": "",
+                                    "cust_id_from": "",
+                                    "cust_id_to": "",
+                                    "amount": Decimal("280.684"),
+                                    "amount_signed": Decimal("280.684"),
+                                    "unit": "hive",
+                                    "conv": {
+                                        "hive": Decimal("280.684"),
+                                        "hbd": Decimal(0),
+                                        "usd": Decimal(0),
+                                        "sats": Decimal(0),
+                                        "msats": Decimal(0),
+                                    },
+                                    "conv_signed": {
+                                        "hive": Decimal("280.684"),
+                                        "hbd": Decimal(0),
+                                        "usd": Decimal(0),
+                                        "sats": Decimal(0),
+                                        "msats": Decimal(0),
+                                    },
+                                    "op_type": "",
+                                    "link": "",
+                                    "side": "debit",
+                                    "account_type": "Asset",
+                                    "name": "Customer Deposits Hive",
+                                    "sub": "devser.v4vapp",
+                                    "contra": False,
+                                }
+                            ]
+                        },
+                    }
+                ]
+            )
+
+    monkeypatch.setattr(
+        "v4vapp_backend_v2.accounting.ledger_checkpoints.get_latest_checkpoint_before",
+        fake_get_latest_checkpoint_before,
+    )
+    monkeypatch.setattr(
+        "v4vapp_backend_v2.accounting.account_balances.LedgerEntry.collection",
+        classmethod(lambda cls: FakeCollection()),
+    )
+
+    result = await one_account_balance(
+        account,
+        as_of_date=datetime(2026, 4, 18, 8, 38, 2, tzinfo=timezone.utc),
+        in_progress=InProgressResults(results=[]),
+        use_cache=False,
+        use_checkpoints=True,
+    )
+
+    assert result.balances_net[Currency.HBD] == Decimal("1.745")
 
 
 @pytest.mark.asyncio

--- a/tests/overwatch/test_balance_request_flow.py
+++ b/tests/overwatch/test_balance_request_flow.py
@@ -19,6 +19,7 @@ from v4vapp_backend_v2.process.overwatch_flows import (
     BALANCE_REQUEST_FLOW,
     HIVE_TO_KEEPSATS_EXTERNAL_FLOW,
     HIVE_TO_KEEPSATS_FLOW,
+    HIVE_TRANSFER_FAILURE_FLOW,
     HIVE_TRANSFER_PAYWITHSATS_FLOW,
     check_balance_request,
 )
@@ -83,12 +84,13 @@ def _fake_op(
 
 
 def _register_transfer_flows() -> Overwatch:
-    """Register all four transfer-triggered flow definitions."""
+    """Register all transfer-triggered flow definitions."""
     Overwatch.reset()
     ow = Overwatch()
     Overwatch.register_flow(HIVE_TO_KEEPSATS_FLOW)
     Overwatch.register_flow(HIVE_TO_KEEPSATS_EXTERNAL_FLOW)
     Overwatch.register_flow(HIVE_TRANSFER_PAYWITHSATS_FLOW)
+    Overwatch.register_flow(HIVE_TRANSFER_FAILURE_FLOW)
     Overwatch.register_flow(BALANCE_REQUEST_FLOW)
     Overwatch._loaded_from_redis = True
     return ow
@@ -145,18 +147,19 @@ class TestBalanceRequestDefinition:
 
 class TestBalanceRequestOverwatch:
     @pytest.mark.asyncio
-    async def test_transfer_creates_four_candidates(self):
-        """A balance-request transfer trigger creates all four transfer-triggered flows."""
+    async def test_transfer_creates_five_candidates(self):
+        """A balance-request transfer trigger creates all five transfer-triggered flows."""
         ow = _register_transfer_flows()
         fake = _fake_op(balance_request=True)
         event = _op_event("transfer", op=fake)
         await ow._try_create_flow(event, fake)
-        assert len(ow.active_flows) == 4
+        assert len(ow.active_flows) == 5
         names = {f.flow_definition.name for f in ow.active_flows}
         assert names == {
             "hive_to_keepsats",
             "hive_to_keepsats_external",
             "hive_transfer_paywithsats",
+            "hive_transfer_failure",
             "balance_request",
         }
 
@@ -286,10 +289,10 @@ class TestCancelFlowsForTrigger:
         fake = _fake_op(balance_request=True)
         trigger = _op_event("transfer", op=fake)
         await ow._try_create_flow(trigger, fake)
-        assert len(ow.active_flows) == 4
+        assert len(ow.active_flows) == 5
 
         cancelled = await ow.cancel_flows_for_trigger("gid_trigger")
-        assert cancelled == 4
+        assert cancelled == 5
         assert len(ow.active_flows) == 0
         assert len(ow.completed_flows) == 0
 
@@ -309,11 +312,11 @@ class TestCancelFlowsForTrigger:
             _op_event("transfer", group_id="gid_b", short_id="bbbb_bbbbbb_1", op=fake_b),
             fake_b,
         )
-        assert len(ow.active_flows) == 8  # 4 per trigger
+        assert len(ow.active_flows) == 10  # 5 per trigger
 
         cancelled = await ow.cancel_flows_for_trigger("gid_a")
-        assert cancelled == 4
-        assert len(ow.active_flows) == 4
+        assert cancelled == 5
+        assert len(ow.active_flows) == 5
         remaining_triggers = {f.trigger_group_id for f in ow.active_flows}
         assert remaining_triggers == {"gid_b"}
 
@@ -423,16 +426,17 @@ class TestEventFilter:
         assert stage.matches(event) is False
 
     @pytest.mark.asyncio
-    async def test_non_balance_request_creates_three_candidates(self):
-        """A non-balance-request transfer only creates 3 candidates
-        (balance_request flow is filtered out)."""
+    async def test_non_balance_request_creates_four_candidates(self):
+        """A non-balance-request transfer creates 4 candidates
+        (balance_request flow is filtered out, but failure flow is not)."""
         ow = _register_transfer_flows()
         fake = _fake_op(balance_request=False)
         event = _op_event("transfer", op=fake)
         await ow._try_create_flow(event, fake)
-        assert len(ow.active_flows) == 3
+        assert len(ow.active_flows) == 4
         names = {f.flow_definition.name for f in ow.active_flows}
         assert "balance_request" not in names
+        assert "hive_transfer_failure" in names
 
     def test_event_filter_excluded_from_serialization(self):
         """event_filter should not appear in model_dump (excluded from Redis)."""

--- a/tests/overwatch/test_external_to_hive_flow.py
+++ b/tests/overwatch/test_external_to_hive_flow.py
@@ -22,6 +22,7 @@ from v4vapp_backend_v2.process.overwatch_flows import (
     EXTERNAL_TO_KEEPSATS_LOOPBACK_FLOW,
     HIVE_TO_KEEPSATS_EXTERNAL_FLOW,
     HIVE_TO_KEEPSATS_FLOW,
+    HIVE_TRANSFER_FAILURE_FLOW,
     HIVE_TRANSFER_PAYWITHSATS_FLOW,
     KEEPSATS_INTERNAL_TRANSFER_FLOW,
     KEEPSATS_TO_EXTERNAL_FLOW,
@@ -170,6 +171,7 @@ class TestExternalToHiveSuperset:
         Overwatch.register_flow(EXTERNAL_TO_HIVE_LOOPBACK_FLOW)
         Overwatch.register_flow(KEEPSATS_INTERNAL_TRANSFER_FLOW)
         Overwatch.register_flow(HIVE_TRANSFER_PAYWITHSATS_FLOW)
+        Overwatch.register_flow(HIVE_TRANSFER_FAILURE_FLOW)
         Overwatch._loaded_from_redis = True
         return ow
 

--- a/tests/overwatch/test_external_to_keepsats_flow.py
+++ b/tests/overwatch/test_external_to_keepsats_flow.py
@@ -22,6 +22,7 @@ from v4vapp_backend_v2.process.overwatch_flows import (
     EXTERNAL_TO_KEEPSATS_LOOPBACK_FLOW,
     HIVE_TO_KEEPSATS_EXTERNAL_FLOW,
     HIVE_TO_KEEPSATS_FLOW,
+    HIVE_TRANSFER_FAILURE_FLOW,
     HIVE_TRANSFER_PAYWITHSATS_FLOW,
     KEEPSATS_INTERNAL_TRANSFER_FLOW,
     KEEPSATS_TO_EXTERNAL_FLOW,
@@ -142,6 +143,7 @@ class TestExternalToKeepsatsOverwatch:
         Overwatch.register_flow(EXTERNAL_TO_HIVE_LOOPBACK_FLOW)
         Overwatch.register_flow(KEEPSATS_INTERNAL_TRANSFER_FLOW)
         Overwatch.register_flow(HIVE_TRANSFER_PAYWITHSATS_FLOW)
+        Overwatch.register_flow(HIVE_TRANSFER_FAILURE_FLOW)
         Overwatch._loaded_from_redis = True
         return ow
 

--- a/tests/overwatch/test_hive_transfer_failure_flow.py
+++ b/tests/overwatch/test_hive_transfer_failure_flow.py
@@ -1,0 +1,286 @@
+"""
+Tests for the Hive Transfer Failure flow.
+
+Flow: User sends a HIVE/HBD transfer to the server account, but the system
+cannot process the request (amount below minimum, above maximum, conversion
+limits exceeded, Lightning decode failure, LND payment failure, etc.).
+The system returns the full amount to the sender.
+
+This flow has the same stage signatures as balance_request, but without the
+event_filter — it acts as a catch-all for any transfer that ends in an
+immediate refund.  When balance_request also matches (because the memo is
+``#balance_request``), both flows complete simultaneously and the superset
+candidates (hive_to_keepsats, hive_to_keepsats_external) are placed in
+grace — the correct behaviour.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from v4vapp_backend_v2.accounting.ledger_type_class import LedgerType
+from v4vapp_backend_v2.process.overwatch_flows import (
+    HIVE_TO_KEEPSATS_EXTERNAL_FLOW,
+    HIVE_TO_KEEPSATS_FLOW,
+    HIVE_TRANSFER_FAILURE_FLOW,
+    HIVE_TRANSFER_PAYWITHSATS_FLOW,
+)
+from v4vapp_backend_v2.process.process_overwatch import FlowEvent, FlowStatus, Overwatch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_TS = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _op_event(
+    op_type: str,
+    group_id: str = "gid_trigger",
+    short_id: str = "5691_010648_23",
+) -> FlowEvent:
+    return FlowEvent(
+        event_type="op",
+        timestamp=_TS,
+        group_id=group_id,
+        short_id=short_id,
+        op_type=op_type,
+        group="primary",
+    )
+
+
+def _ledger_event(
+    ledger_type: LedgerType,
+    group_id: str = "gid_trigger",
+    short_id: str = "5691_010648_23",
+) -> FlowEvent:
+    return FlowEvent(
+        event_type="ledger",
+        timestamp=_TS,
+        group_id=group_id,
+        short_id=short_id,
+        ledger_type=ledger_type,
+        group="primary",
+    )
+
+
+def _fake_op(
+    group_id: str = "gid_trigger",
+    short_id: str = "5691_010648_23",
+) -> object:
+    return type(
+        "FakeOp",
+        (),
+        {
+            "group_id": group_id,
+            "short_id": short_id,
+            "op_type": "transfer",
+            "from_account": "magi.network",
+        },
+    )()
+
+
+def _register_transfer_flows() -> Overwatch:
+    """Register the transfer-triggered flow definitions (no balance_request)."""
+    Overwatch.reset()
+    ow = Overwatch()
+    Overwatch.register_flow(HIVE_TO_KEEPSATS_FLOW)
+    Overwatch.register_flow(HIVE_TO_KEEPSATS_EXTERNAL_FLOW)
+    Overwatch.register_flow(HIVE_TRANSFER_PAYWITHSATS_FLOW)
+    Overwatch.register_flow(HIVE_TRANSFER_FAILURE_FLOW)
+    Overwatch._loaded_from_redis = True
+    return ow
+
+
+# ---------------------------------------------------------------------------
+# Tests: FlowDefinition
+# ---------------------------------------------------------------------------
+
+
+class TestHiveTransferFailureDefinition:
+    def test_definition_exists(self):
+        assert HIVE_TRANSFER_FAILURE_FLOW.name == "hive_transfer_failure"
+        assert HIVE_TRANSFER_FAILURE_FLOW.trigger_op_type == "transfer"
+
+    def test_has_4_required_stages(self):
+        assert len(HIVE_TRANSFER_FAILURE_FLOW.required_stages) == 4
+
+    def test_has_4_total_stages(self):
+        assert len(HIVE_TRANSFER_FAILURE_FLOW.stages) == 4
+
+    def test_stage_names(self):
+        names = HIVE_TRANSFER_FAILURE_FLOW.stage_names
+        assert names == [
+            "trigger_transfer",
+            "customer_hive_in",
+            "refund_transfer_op",
+            "customer_hive_out",
+        ]
+
+    def test_no_optional_stages(self):
+        optional = [s for s in HIVE_TRANSFER_FAILURE_FLOW.stages if not s.required]
+        assert len(optional) == 0
+
+    def test_no_event_filter_on_trigger(self):
+        trigger = HIVE_TRANSFER_FAILURE_FLOW.stages[0]
+        assert trigger.event_filter is None
+
+    def test_same_stage_sigs_as_balance_request(self):
+        """Failure flow has identical stage signatures to balance_request."""
+        from v4vapp_backend_v2.process.overwatch_flows import BALANCE_REQUEST_FLOW
+
+        def _sig(s):
+            return (s.event_type, s.op_type, s.ledger_type)
+
+        failure_sigs = {_sig(s) for s in HIVE_TRANSFER_FAILURE_FLOW.stages}
+        br_sigs = {_sig(s) for s in BALANCE_REQUEST_FLOW.stages}
+        assert failure_sigs == br_sigs
+
+
+# ---------------------------------------------------------------------------
+# Tests: Overwatch integration
+# ---------------------------------------------------------------------------
+
+
+class TestHiveTransferFailureOverwatch:
+    @pytest.mark.asyncio
+    async def test_transfer_creates_four_candidates(self):
+        """A transfer trigger creates hive_to_keepsats, hive_to_keepsats_external,
+        hive_transfer_paywithsats, and hive_transfer_failure."""
+        ow = _register_transfer_flows()
+        event = _op_event("transfer")
+        await ow._try_create_flow(event, _fake_op())
+        assert len(ow.active_flows) == 4
+        names = {f.flow_definition.name for f in ow.active_flows}
+        assert names == {
+            "hive_to_keepsats",
+            "hive_to_keepsats_external",
+            "hive_transfer_paywithsats",
+            "hive_transfer_failure",
+        }
+
+    @pytest.mark.asyncio
+    async def test_failure_flow_completes_on_refund(self):
+        """Failure flow completes when the refund transfer and CUSTOMER_HIVE_OUT
+        arrive (full 4-stage sequence)."""
+        ow = _register_transfer_flows()
+        trigger = _op_event("transfer")
+        await ow._try_create_flow(trigger, _fake_op())
+
+        # Primary: CUSTOMER_HIVE_IN
+        await ow._dispatch(_ledger_event(LedgerType.CUSTOMER_HIVE_IN))
+        # Refund: transfer op (different short_id — the return transfer)
+        await ow._dispatch(_op_event("transfer", group_id="gid_refund", short_id="5691_010648_24"))
+        # Refund: CUSTOMER_HIVE_OUT
+        await ow._dispatch(
+            _ledger_event(
+                LedgerType.CUSTOMER_HIVE_OUT,
+                group_id="gid_refund",
+                short_id="5691_010648_24",
+            )
+        )
+
+        completed_names = {f.flow_definition.name for f in ow.completed_flows}
+        assert "hive_transfer_failure" in completed_names
+
+    @pytest.mark.asyncio
+    async def test_superset_candidates_get_grace_period(self):
+        """When failure flow completes, hive_to_keepsats and
+        hive_to_keepsats_external are kept as superset candidates
+        because their stage signatures are a proper superset of the
+        failure flow's."""
+        ow = _register_transfer_flows()
+        trigger = _op_event("transfer")
+        await ow._try_create_flow(trigger, _fake_op())
+
+        await ow._dispatch(_ledger_event(LedgerType.CUSTOMER_HIVE_IN))
+        await ow._dispatch(_op_event("transfer", group_id="gid_refund", short_id="5691_010648_24"))
+        await ow._dispatch(
+            _ledger_event(
+                LedgerType.CUSTOMER_HIVE_OUT,
+                group_id="gid_refund",
+                short_id="5691_010648_24",
+            )
+        )
+
+        superset_flows = [f for f in ow.active_flows if f.superset_grace_expires is not None]
+        superset_names = {f.flow_definition.name for f in superset_flows}
+        assert "hive_to_keepsats" in superset_names
+        assert "hive_to_keepsats_external" in superset_names
+
+    @pytest.mark.asyncio
+    async def test_paywithsats_removed_on_failure_completion(self):
+        """When failure flow completes, paywithsats is removed because
+        its stage signatures are not a superset of the failure flow's
+        (and vice versa)."""
+        ow = _register_transfer_flows()
+        trigger = _op_event("transfer")
+        await ow._try_create_flow(trigger, _fake_op())
+
+        await ow._dispatch(_ledger_event(LedgerType.CUSTOMER_HIVE_IN))
+        await ow._dispatch(_op_event("transfer", group_id="gid_refund", short_id="5691_010648_24"))
+        await ow._dispatch(
+            _ledger_event(
+                LedgerType.CUSTOMER_HIVE_OUT,
+                group_id="gid_refund",
+                short_id="5691_010648_24",
+            )
+        )
+
+        active_names = {f.flow_definition.name for f in ow.active_flows}
+        assert "hive_transfer_paywithsats" not in active_names
+
+    @pytest.mark.asyncio
+    async def test_progress_reporting(self):
+        """Progress reports correctly at each stage."""
+        Overwatch.reset()
+        ow = Overwatch()
+        Overwatch.register_flow(HIVE_TRANSFER_FAILURE_FLOW)
+        Overwatch._loaded_from_redis = True
+
+        trigger = _op_event("transfer")
+        await ow._try_create_flow(trigger, _fake_op())
+        flow = ow.active_flows[0]
+        assert flow.progress == "1/4 required stages complete"
+
+        await ow._dispatch(_ledger_event(LedgerType.CUSTOMER_HIVE_IN))
+        assert flow.progress == "2/4 required stages complete"
+
+        await ow._dispatch(_op_event("transfer", group_id="gid_refund", short_id="5691_010648_24"))
+        assert flow.progress == "3/4 required stages complete"
+
+        await ow._dispatch(
+            _ledger_event(
+                LedgerType.CUSTOMER_HIVE_OUT,
+                group_id="gid_refund",
+                short_id="5691_010648_24",
+            )
+        )
+        assert flow.status == FlowStatus.COMPLETED
+        assert flow.progress == "4/4 required stages complete"
+
+    @pytest.mark.asyncio
+    async def test_single_flow_no_superset_conflict(self):
+        """When only failure flow is registered, no superset resolution needed."""
+        Overwatch.reset()
+        ow = Overwatch()
+        Overwatch.register_flow(HIVE_TRANSFER_FAILURE_FLOW)
+        Overwatch._loaded_from_redis = True
+
+        trigger = _op_event("transfer")
+        await ow._try_create_flow(trigger, _fake_op())
+        assert len(ow.active_flows) == 1
+
+        await ow._dispatch(_ledger_event(LedgerType.CUSTOMER_HIVE_IN))
+        await ow._dispatch(_op_event("transfer", group_id="gid_refund", short_id="5691_010648_24"))
+        await ow._dispatch(
+            _ledger_event(
+                LedgerType.CUSTOMER_HIVE_OUT,
+                group_id="gid_refund",
+                short_id="5691_010648_24",
+            )
+        )
+
+        assert len(ow.completed_flows) == 1
+        assert len(ow.active_flows) == 0
+        assert ow.completed_flows[0].flow_definition.name == "hive_transfer_failure"

--- a/tests/overwatch/test_hive_transfer_paywithsats_flow.py
+++ b/tests/overwatch/test_hive_transfer_paywithsats_flow.py
@@ -17,6 +17,7 @@ from v4vapp_backend_v2.accounting.ledger_type_class import LedgerType
 from v4vapp_backend_v2.process.overwatch_flows import (
     HIVE_TO_KEEPSATS_EXTERNAL_FLOW,
     HIVE_TO_KEEPSATS_FLOW,
+    HIVE_TRANSFER_FAILURE_FLOW,
     HIVE_TRANSFER_PAYWITHSATS_FLOW,
 )
 from v4vapp_backend_v2.process.process_overwatch import FlowEvent, FlowStatus, Overwatch
@@ -76,12 +77,13 @@ def _fake_op(
 
 
 def _register_transfer_flows() -> Overwatch:
-    """Register the three transfer-triggered flow definitions."""
+    """Register the transfer-triggered flow definitions."""
     Overwatch.reset()
     ow = Overwatch()
     Overwatch.register_flow(HIVE_TO_KEEPSATS_FLOW)
     Overwatch.register_flow(HIVE_TO_KEEPSATS_EXTERNAL_FLOW)
     Overwatch.register_flow(HIVE_TRANSFER_PAYWITHSATS_FLOW)
+    Overwatch.register_flow(HIVE_TRANSFER_FAILURE_FLOW)
     Overwatch._loaded_from_redis = True
     return ow
 
@@ -133,18 +135,20 @@ class TestHiveTransferPaywithsatsDefinition:
 
 class TestHiveTransferPaywithsatsOverwatch:
     @pytest.mark.asyncio
-    async def test_transfer_creates_three_candidates(self):
+    async def test_transfer_creates_four_candidates(self):
         """A transfer trigger should create hive_to_keepsats,
-        hive_to_keepsats_external, and hive_transfer_paywithsats."""
+        hive_to_keepsats_external, hive_transfer_paywithsats, and
+        hive_transfer_failure."""
         ow = _register_transfer_flows()
         event = _op_event("transfer")
         await ow._try_create_flow(event, _fake_op())
-        assert len(ow.active_flows) == 3
+        assert len(ow.active_flows) == 4
         names = {f.flow_definition.name for f in ow.active_flows}
         assert names == {
             "hive_to_keepsats",
             "hive_to_keepsats_external",
             "hive_transfer_paywithsats",
+            "hive_transfer_failure",
         }
 
     @pytest.mark.asyncio

--- a/tests/overwatch/test_keepsats_internal_transfer_flow.py
+++ b/tests/overwatch/test_keepsats_internal_transfer_flow.py
@@ -21,6 +21,7 @@ from v4vapp_backend_v2.process.overwatch_flows import (
     EXTERNAL_TO_KEEPSATS_LOOPBACK_FLOW,
     HIVE_TO_KEEPSATS_EXTERNAL_FLOW,
     HIVE_TO_KEEPSATS_FLOW,
+    HIVE_TRANSFER_FAILURE_FLOW,
     HIVE_TRANSFER_PAYWITHSATS_FLOW,
     KEEPSATS_INTERNAL_TRANSFER_FLOW,
     KEEPSATS_TO_EXTERNAL_FLOW,
@@ -95,6 +96,7 @@ def _register_all() -> Overwatch:
     Overwatch.register_flow(EXTERNAL_TO_HIVE_LOOPBACK_FLOW)
     Overwatch.register_flow(KEEPSATS_INTERNAL_TRANSFER_FLOW)
     Overwatch.register_flow(HIVE_TRANSFER_PAYWITHSATS_FLOW)
+    Overwatch.register_flow(HIVE_TRANSFER_FAILURE_FLOW)
     Overwatch._loaded_from_redis = True
     return ow
 

--- a/tests/overwatch/test_overwatch_flow.py
+++ b/tests/overwatch/test_overwatch_flow.py
@@ -642,14 +642,14 @@ class TestFlowInstanceMatching:
 
 
 # ---------------------------------------------------------------------------
-# Tests: op_log_str population
+# Tests: event_log_str population
 # ---------------------------------------------------------------------------
 
 
 class TestOpLogStr:
-    """Tests that FlowStage.op_log_str is populated from FlowEvent.log_str."""
+    """Tests that FlowStage.event_log_str is populated from FlowEvent.log_str."""
 
-    def test_op_log_str_set_on_match(
+    def test_event_log_str_set_on_match(
         self,
         flow_instance: FlowInstance,
         primary_ledger_entries: dict[str, LedgerEntry],
@@ -660,15 +660,15 @@ class TestOpLogStr:
         stage = next(
             s for s in flow_instance.flow_definition.stages if s.name == "customer_hive_in"
         )
-        assert stage.op_log_str == event.log_str
-        assert stage.op_log_str != ""
+        assert stage.event_log_str == event.log_str
+        assert stage.event_log_str != ""
 
-    def test_op_log_str_empty_before_match(
+    def test_event_log_str_empty_before_match(
         self,
         flow_instance: FlowInstance,
     ):
         for stage in flow_instance.flow_definition.stages:
-            assert stage.op_log_str == ""
+            assert stage.event_log_str == ""
 
     def test_all_stages_have_log_str_after_complete(
         self,
@@ -679,9 +679,9 @@ class TestOpLogStr:
             flow_instance.add_event(event)
         assert flow_instance.is_complete
         for stage in flow_instance.flow_definition.stages:
-            assert stage.op_log_str != "", f"Stage '{stage.name}' has no op_log_str"
+            assert stage.event_log_str != "", f"Stage '{stage.name}' has no event_log_str"
 
-    def test_op_log_str_isolated_between_instances(self):
+    def test_event_log_str_isolated_between_instances(self):
         """Each FlowInstance gets its own deep-copied stages."""
         defn = FlowDefinition(
             name="test",
@@ -696,10 +696,10 @@ class TestOpLogStr:
         event = FlowEvent(event_type="op", op_type="transfer")
         inst_a.add_event(event)
 
-        assert inst_a.flow_definition.stages[0].op_log_str != ""
-        assert inst_b.flow_definition.stages[0].op_log_str == ""
+        assert inst_a.flow_definition.stages[0].event_log_str != ""
+        assert inst_b.flow_definition.stages[0].event_log_str == ""
         # Template definition is also unchanged
-        assert defn.stages[0].op_log_str == ""
+        assert defn.stages[0].event_log_str == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/overwatch/test_overwatch_flow.py
+++ b/tests/overwatch/test_overwatch_flow.py
@@ -642,6 +642,67 @@ class TestFlowInstanceMatching:
 
 
 # ---------------------------------------------------------------------------
+# Tests: op_log_str population
+# ---------------------------------------------------------------------------
+
+
+class TestOpLogStr:
+    """Tests that FlowStage.op_log_str is populated from FlowEvent.log_str."""
+
+    def test_op_log_str_set_on_match(
+        self,
+        flow_instance: FlowInstance,
+        primary_ledger_entries: dict[str, LedgerEntry],
+    ):
+        le = primary_ledger_entries["cust_h_in"]
+        event = FlowEvent.from_ledger_entry(le)
+        flow_instance.add_event(event)
+        stage = next(
+            s for s in flow_instance.flow_definition.stages if s.name == "customer_hive_in"
+        )
+        assert stage.op_log_str == event.log_str
+        assert stage.op_log_str != ""
+
+    def test_op_log_str_empty_before_match(
+        self,
+        flow_instance: FlowInstance,
+    ):
+        for stage in flow_instance.flow_definition.stages:
+            assert stage.op_log_str == ""
+
+    def test_all_stages_have_log_str_after_complete(
+        self,
+        flow_instance: FlowInstance,
+        all_flow_events: list[FlowEvent],
+    ):
+        for event in all_flow_events:
+            flow_instance.add_event(event)
+        assert flow_instance.is_complete
+        for stage in flow_instance.flow_definition.stages:
+            assert stage.op_log_str != "", f"Stage '{stage.name}' has no op_log_str"
+
+    def test_op_log_str_isolated_between_instances(self):
+        """Each FlowInstance gets its own deep-copied stages."""
+        defn = FlowDefinition(
+            name="test",
+            trigger_op_type="transfer",
+            stages=[
+                FlowStage(name="trigger", event_type="op", op_type="transfer"),
+            ],
+        )
+        inst_a = FlowInstance(flow_definition=defn)
+        inst_b = FlowInstance(flow_definition=defn)
+
+        event = FlowEvent(event_type="op", op_type="transfer")
+        inst_a.add_event(event)
+
+        assert inst_a.flow_definition.stages[0].op_log_str != ""
+        assert inst_b.flow_definition.stages[0].op_log_str == ""
+        # Template definition is also unchanged
+        assert defn.stages[0].op_log_str == ""
+
+
+# ---------------------------------------------------------------------------
 # Tests: Overwatch singleton
 # ---------------------------------------------------------------------------
 

--- a/uv.lock
+++ b/uv.lock
@@ -3714,7 +3714,7 @@ wheels = [
 
 [[package]]
 name = "v4vapp-backend-v2"
-version = "2.7.11"
+version = "2.7.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION

Problem fixed
The ledger checkpoint logic was losing checkpoint-only currencies when no post-checkpoint delta rows existed for that currency.
That caused accounts like Customer Deposits Hive / devser.v4vapp to appear with 0.0 HBD in sanity-check/account printout views even though the carried-forward HBD balance existed in the checkpoint.
What changed
In account_balances.py
one_account_balance() now injects synthetic checkpoint-only AccountBalanceLine rows for currencies present in the checkpoint but missing from the delta query.
This preserves carried-forward checkpoint balances for HBD and other currencies even when the current period has no transactions for them.
account_balance_printout() and account_balance_printout_grouped_by_customer() now also add synthetic opening balance rows for currencies that exist only in the carried-forward opening balance and have no current-period rows.
Regression coverage
Added test_account_balance_printout_includes_opening_only_currency_rows in test_account_balances.py
Verifies that Unit: HBD and the Carried Forward (from ...) opening-only row appear in both normal and grouped-by-customer printouts.
Result
Checkpoint balances are now preserved across the balance calculation pipeline.
Period-filtered and grouped display views correctly show carried-forward HBD rows instead of dropping them.