### PR TITLE
Implement completion report deduplication for Overwatch flows

### DIFF
--- a/src/v4vapp_backend_v2/process/process_overwatch.py
+++ b/src/v4vapp_backend_v2/process/process_overwatch.py
@@ -52,6 +52,22 @@ _COMPLETED_TTL_SECONDS = 24 * 60 * 60  # 24 hours
 _LATE_EVENT_WINDOW = timedelta(seconds=120)  # only absorb late events into recent completions
 
 
+def _swallow_task_exception(task: asyncio.Task) -> None:  # type: ignore[type-arg]
+    """Done-callback that consumes exceptions from fire-and-forget tasks.
+
+    Prevents "Task exception was never retrieved" log noise for tasks that
+    are cancelled (normal timer-reset path) or raise an unexpected error.
+    CancelledError is not an exception on a cancelled task, so we only log
+    genuine unexpected errors at DEBUG level.
+    """
+    if not task.cancelled():
+        exc = task.exception()
+        if exc is not None:
+            from v4vapp_backend_v2.config.setup import logger as _logger
+
+            _logger.debug(f"{ICON} completion-report task raised: {exc!r}")
+
+
 # ---------------------------------------------------------------------------
 # Flow status enum
 # ---------------------------------------------------------------------------
@@ -558,13 +574,6 @@ class Overwatch:
     _completion_report_tasks: ClassVar[dict[str, asyncio.Task]] = {}
     COMPLETION_REPORT_DELAY: ClassVar[float] = 5.0  # seconds
 
-    # ---- completion report deduplication ----
-    # Maps trigger_group_id -> list of completed FlowInstances waiting to be reported.
-    # A single delayed task fires per group and only logs the flow with the most stages.
-    _pending_completion_reports: ClassVar[dict[str, list[FlowInstance]]] = {}
-    _completion_report_tasks: ClassVar[dict[str, asyncio.Task]] = {}
-    COMPLETION_REPORT_DELAY: ClassVar[float] = 5.0  # seconds
-
     def __new__(cls) -> Overwatch:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
@@ -962,15 +971,25 @@ class Overwatch:
         existing = self._completion_report_tasks.get(gid)
         if existing and not existing.done():
             existing.cancel()
-        self._completion_report_tasks[gid] = asyncio.create_task(self._fire_completion_report(gid))
+        task = asyncio.create_task(self._fire_completion_report(gid))
+        # Attach a callback so that any unexpected exception is consumed
+        # rather than surfacing as "Task exception was never retrieved".
+        task.add_done_callback(_swallow_task_exception)
+        self._completion_report_tasks[gid] = task
 
     async def _fire_completion_report(self, trigger_group_id: str) -> None:
         """After a delay, log only the best-completed flow for *trigger_group_id*.
 
         "Best" is the flow with the most required stages (highest total count),
         which corresponds to the most specific / successful flow variant.
+
+        Cancellation is the normal path when a later sibling completion
+        resets the timer — it is caught here and exits silently.
         """
-        await asyncio.sleep(self.COMPLETION_REPORT_DELAY)
+        try:
+            await asyncio.sleep(self.COMPLETION_REPORT_DELAY)
+        except asyncio.CancelledError:
+            return  # superseded by a newer enqueue — exit cleanly
         flows = self._pending_completion_reports.pop(trigger_group_id, [])
         self._completion_report_tasks.pop(trigger_group_id, None)
         if not flows:
@@ -1433,6 +1452,11 @@ class Overwatch:
         cls.stall_log_interval = DEFAULT_STALL_LOG_INTERVAL
         cls._loaded_from_redis = False
         cls._instance = None
+        # Cancel any in-flight completion report tasks
+        for task in cls._completion_report_tasks.values():
+            task.cancel()
+        cls._pending_completion_reports.clear()
+        cls._completion_report_tasks.clear()
 
     async def reset_redis(self) -> None:
         """Clear all overwatch data from Redis."""

--- a/src/v4vapp_backend_v2/process/process_overwatch.py
+++ b/src/v4vapp_backend_v2/process/process_overwatch.py
@@ -551,6 +551,20 @@ class Overwatch:
     stall_log_interval: ClassVar[timedelta] = DEFAULT_STALL_LOG_INTERVAL
     _loaded_from_redis: ClassVar[bool] = False
 
+    # ---- completion report deduplication ----
+    # Maps trigger_group_id -> list of completed FlowInstances waiting to be reported.
+    # A single delayed task fires per group and only logs the flow with the most stages.
+    _pending_completion_reports: ClassVar[dict[str, list[FlowInstance]]] = {}
+    _completion_report_tasks: ClassVar[dict[str, asyncio.Task]] = {}
+    COMPLETION_REPORT_DELAY: ClassVar[float] = 5.0  # seconds
+
+    # ---- completion report deduplication ----
+    # Maps trigger_group_id -> list of completed FlowInstances waiting to be reported.
+    # A single delayed task fires per group and only logs the flow with the most stages.
+    _pending_completion_reports: ClassVar[dict[str, list[FlowInstance]]] = {}
+    _completion_report_tasks: ClassVar[dict[str, asyncio.Task]] = {}
+    COMPLETION_REPORT_DELAY: ClassVar[float] = 5.0  # seconds
+
     def __new__(cls) -> Overwatch:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
@@ -726,13 +740,11 @@ class Overwatch:
             )
         if loaded:
             # compute status breakdown for reporting
-            act = len(
-                [
-                    f
-                    for f in self.flow_instances
-                    if f.status not in (FlowStatus.COMPLETED, FlowStatus.FAILED)
-                ]
-            )
+            act = len([
+                f
+                for f in self.flow_instances
+                if f.status not in (FlowStatus.COMPLETED, FlowStatus.FAILED)
+            ])
             stl = len([f for f in self.flow_instances if f.status == FlowStatus.STALLED])
             comp = len([f for f in self.flow_instances if f.status == FlowStatus.COMPLETED])
             logger.info(
@@ -885,8 +897,7 @@ class Overwatch:
                         flow.superset_winner_name = None
                 if flow.is_complete:
                     newly_completed.append(flow)
-                    message = f"{ICON} ✅ {Fore.WHITE}{flow.log_str} {Fore.RESET}"
-                    asyncio.create_task(self._delay_log(flow, message))
+                    self._enqueue_completion_report(flow)
                 await self._persist_flow(flow)
         for completed in newly_completed:
             await self._resolve_candidates(completed)
@@ -933,6 +944,46 @@ class Overwatch:
                 "notification": notification,
                 "notification_str": f"{ICON} ✅ {flow.notification_str}",
                 **flow.log_extra,
+            },
+        )
+
+    def _enqueue_completion_report(self, flow: FlowInstance) -> None:
+        """Add *flow* to the pending report group and (re-)arm the delayed task.
+
+        A single :py:meth:`_fire_completion_report` task fires per
+        ``trigger_group_id`` after ``COMPLETION_REPORT_DELAY`` seconds.  If
+        the task is already scheduled we cancel and re-schedule it so the
+        window is always measured from the *last* completion, giving all
+        sibling flows a chance to finish before we pick the winner.
+        """
+        gid = flow.trigger_group_id
+        self._pending_completion_reports.setdefault(gid, []).append(flow)
+        # Cancel any already-scheduled task and replace it.
+        existing = self._completion_report_tasks.get(gid)
+        if existing and not existing.done():
+            existing.cancel()
+        self._completion_report_tasks[gid] = asyncio.create_task(self._fire_completion_report(gid))
+
+    async def _fire_completion_report(self, trigger_group_id: str) -> None:
+        """After a delay, log only the best-completed flow for *trigger_group_id*.
+
+        "Best" is the flow with the most required stages (highest total count),
+        which corresponds to the most specific / successful flow variant.
+        """
+        await asyncio.sleep(self.COMPLETION_REPORT_DELAY)
+        flows = self._pending_completion_reports.pop(trigger_group_id, [])
+        self._completion_report_tasks.pop(trigger_group_id, None)
+        if not flows:
+            return
+        # Pick the flow with the highest required-stage count as the winner.
+        best = max(flows, key=lambda f: len(f.flow_definition.required_stages))
+        message = f"{ICON} ✅ {Fore.WHITE}{best.log_str} {Fore.RESET}"
+        logger.info(
+            message,
+            extra={
+                "notification": True,
+                "notification_str": f"{ICON} ✅ {best.notification_str}",
+                **best.log_extra,
             },
         )
 

--- a/tests/overwatch/test_overwatch_flow.py
+++ b/tests/overwatch/test_overwatch_flow.py
@@ -1027,3 +1027,183 @@ class TestFlowDataIntegrity:
         assert trigger["conv"]["msats_fee"] == 68753.0
         # Change is 0.001 HIVE
         assert trigger["change_amount"]["amount"] == "1"  # 0.001 HIVE
+
+
+# ---------------------------------------------------------------------------
+# Tests: completion report deduplication (_enqueue_completion_report /
+#         _fire_completion_report)
+# ---------------------------------------------------------------------------
+
+
+def _make_flow(
+    name: str,
+    trigger_op_type: str,
+    num_required_stages: int,
+    trigger_group_id: str = "grp1",
+    cust_id: str = "testcust",
+) -> FlowInstance:
+    """Create a minimal completed FlowInstance with *num_required_stages* required stages."""
+    stages = [
+        FlowStage(name=f"stage_{i}", event_type="op", op_type=trigger_op_type, required=True)
+        for i in range(num_required_stages)
+    ]
+    defn = FlowDefinition(name=name, trigger_op_type=trigger_op_type, stages=stages)
+    inst = FlowInstance(
+        flow_definition=defn,
+        trigger_group_id=trigger_group_id,
+        trigger_short_id=trigger_group_id[:14],
+        cust_id=cust_id,
+        status=FlowStatus.COMPLETED,
+    )
+    return inst
+
+
+@pytest.mark.asyncio
+class TestCompletionReportDeduplication:
+    """Tests for the deferred, best-winner completion reporting."""
+
+    async def test_single_completion_is_reported(self, caplog):
+        """When only one flow completes for a trigger group, it must be reported."""
+        Overwatch.reset()
+        Overwatch.COMPLETION_REPORT_DELAY = 0.05  # speed up for test
+        ow = Overwatch()
+        flow = _make_flow("flow_a", "transfer", num_required_stages=5)
+
+        caplog.set_level("INFO")
+        ow._enqueue_completion_report(flow)
+
+        # Wait for the delay + a small buffer
+        import asyncio
+
+        await asyncio.sleep(0.2)
+
+        completion_logs = [r for r in caplog.records if "✅" in r.message]
+        assert len(completion_logs) == 1
+        assert completion_logs[0].__dict__["flow"]["flow_type"] == "flow_a"
+
+    async def test_best_flow_wins_not_the_simpler_one(self, caplog):
+        """With two competing completions the one with more stages must be logged."""
+        Overwatch.reset()
+        Overwatch.COMPLETION_REPORT_DELAY = 0.05
+        ow = Overwatch()
+
+        simple = _make_flow("simple_flow", "transfer", num_required_stages=4)
+        detailed = _make_flow("detailed_flow", "transfer", num_required_stages=14)
+
+        caplog.set_level("INFO")
+        ow._enqueue_completion_report(simple)
+        ow._enqueue_completion_report(detailed)
+
+        import asyncio
+
+        await asyncio.sleep(0.2)
+
+        completion_logs = [r for r in caplog.records if "✅" in r.message]
+        assert len(completion_logs) == 1
+        assert completion_logs[0].__dict__["flow"]["flow_type"] == "detailed_flow"
+
+    async def test_failure_flow_not_reported_when_success_has_more_stages(self, caplog):
+        """Mirrors the real-world case: hive_to_keepsats (14 stages) should
+        suppress hive_transfer_failure (4 stages) that completes at the same time."""
+        Overwatch.reset()
+        Overwatch.COMPLETION_REPORT_DELAY = 0.05
+        ow = Overwatch()
+
+        failure = _make_flow("hive_transfer_failure", "transfer", num_required_stages=4)
+        success = _make_flow("hive_to_keepsats", "transfer", num_required_stages=14)
+
+        caplog.set_level("INFO")
+        ow._enqueue_completion_report(failure)
+        ow._enqueue_completion_report(success)
+
+        import asyncio
+
+        await asyncio.sleep(0.2)
+
+        completion_logs = [r for r in caplog.records if "✅" in r.message]
+        assert len(completion_logs) == 1
+        assert completion_logs[0].__dict__["flow"]["flow_type"] == "hive_to_keepsats"
+
+    async def test_timer_resets_on_second_completion(self, caplog):
+        """If a second flow completes shortly after the first, the timer must
+        restart so both are considered before a winner is picked."""
+        Overwatch.reset()
+        Overwatch.COMPLETION_REPORT_DELAY = 0.15
+        ow = Overwatch()
+
+        import asyncio
+
+        simple = _make_flow("flow_small", "transfer", num_required_stages=2)
+        big = _make_flow("flow_big", "transfer", num_required_stages=10)
+
+        caplog.set_level("INFO")
+        ow._enqueue_completion_report(simple)
+        # Enqueue the bigger flow before the first timer fires
+        await asyncio.sleep(0.05)
+        ow._enqueue_completion_report(big)
+
+        # Wait for the reset timer to expire
+        await asyncio.sleep(0.3)
+
+        completion_logs = [r for r in caplog.records if "✅" in r.message]
+        assert len(completion_logs) == 1
+        assert completion_logs[0].__dict__["flow"]["flow_type"] == "flow_big"
+
+    async def test_separate_trigger_groups_reported_independently(self, caplog):
+        """Flows from different trigger groups must each produce their own report."""
+        Overwatch.reset()
+        Overwatch.COMPLETION_REPORT_DELAY = 0.05
+        ow = Overwatch()
+
+        flow_a = _make_flow("flow_a", "transfer", num_required_stages=3, trigger_group_id="grp_A")
+        flow_b = _make_flow("flow_b", "transfer", num_required_stages=3, trigger_group_id="grp_B")
+
+        caplog.set_level("INFO")
+        ow._enqueue_completion_report(flow_a)
+        ow._enqueue_completion_report(flow_b)
+
+        import asyncio
+
+        await asyncio.sleep(0.2)
+
+        completion_logs = [r for r in caplog.records if "✅" in r.message]
+        assert len(completion_logs) == 2
+        reported_types = {r.__dict__["flow"]["flow_type"] for r in completion_logs}
+        assert "flow_a" in reported_types
+        assert "flow_b" in reported_types
+
+    async def test_reset_cancels_pending_report_tasks(self):
+        """After Overwatch.reset() no pending tasks or queued flows remain."""
+        Overwatch.reset()
+        Overwatch.COMPLETION_REPORT_DELAY = 10.0  # long enough to not fire during test
+        ow = Overwatch()
+
+        flow = _make_flow("some_flow", "transfer", num_required_stages=5)
+        ow._enqueue_completion_report(flow)
+
+        # Task should be scheduled
+        assert len(ow._pending_completion_reports) == 1
+        assert len(ow._completion_report_tasks) == 1
+
+        Overwatch.reset()
+
+        assert len(Overwatch._pending_completion_reports) == 0
+        assert len(Overwatch._completion_report_tasks) == 0
+
+    async def test_notification_extra_is_set_on_report(self, caplog):
+        """The completion log record must carry notification=True."""
+        Overwatch.reset()
+        Overwatch.COMPLETION_REPORT_DELAY = 0.05
+        ow = Overwatch()
+
+        flow = _make_flow("notify_flow", "transfer", num_required_stages=3)
+        caplog.set_level("INFO")
+        ow._enqueue_completion_report(flow)
+
+        import asyncio
+
+        await asyncio.sleep(0.2)
+
+        completion_logs = [r for r in caplog.records if "✅" in r.message]
+        assert len(completion_logs) == 1
+        assert completion_logs[0].__dict__.get("notification") is True


### PR DESCRIPTION
Introduce a mechanism to deduplicate completion reports for Overwatch flows, ensuring that only the most relevant flow is logged after a delay. This change enhances reporting efficiency by grouping flows and selecting the best one based on required stages.