### PR TITLE
Fix/deal with residual rounding issues

### DIFF
--- a/docs/ledger_audit_2026_05.md
+++ b/docs/ledger_audit_2026_05.md
@@ -211,3 +211,31 @@ to truncate. Using ROUND_HALF_UP is consistent with `sats_rounded` and gives the
 the nearest-integer approximation of the calculated value. The residual per transaction
 is bounded to ±0.5 msats (whichever rounding direction is closest), which is negligible
 and symmetric across many transactions.
+
+
+# To Fix Outstanding rounding drift in VSC Liability account:
+
+Based on the code and docs, here's the accounting assessment:
+
+**Do not touch the database records. Make a single adjusting journal entry instead.**
+
+Reasons:
+
+1. **Audit trail is sacred** — Double-entry ledger records should be immutable. Retroactively modifying 2,500+ historical `cust_conv` entries would destroy the audit trail. Any future audit would show records that don't match the chain events that created them.
+
+2. **Risk vs. reward is terrible** — Each historical entry is part of a double-entry pair. To correctly round all of them you'd need to update both debit AND credit sides consistently, and the rounding direction on each pair is independent — some fractional parts would have rounded up, some down. Getting this right across 2,500 entries in MongoDB with Decimal math is very risky. The residual is **188 msats ≈ $0.001 at $200k BTC** — not worth it.
+
+3. **This is standard practice** — Every professional accounting system (QuickBooks, SAP, etc.) corrects accumulated rounding drift with a single adjusting entry, never retroactive record modification.
+
+**The right fix is one journal entry:**
+
+```
+Debit:  VSC Liability (sub=v4vapp)  +188 msats   ← reduces phantom liability
+Credit: Fee Income (sub=rounding)   +188 msats   ← recognises it as rounding income
+```
+
+Use `LedgerType.FEE_INCOME` (or add `ROUNDING_ADJUSTMENT` to the enum if you want it clearly labelled), `ledger_type` in the entry, and a description like `"Accumulated sub-msat rounding drift correction — prior to fix/deal-with-residual-rounding-issues"`.
+
+The exact residual amount to use is `188` msats (the 0.2266... fraction rounds down with `ROUND_HALF_UP`) — consistent with your new policy of integer msats in ledger entries.
+
+**Practically speaking**: if `v4vapp` is your own operator account (not an external customer), you could also just leave it. 188 msats will never matter. The fix prevents further accumulation, which is the important part.

--- a/docs/ledger_audit_2026_05.md
+++ b/docs/ledger_audit_2026_05.md
@@ -156,3 +156,58 @@ server-held sats) and `Converted Keepsats Offset / from_keepsats` increases its 
 (partially offsetting `Treasury Lightning / from_keepsats` which is negative by the same magnitude).
 The pair `Converted Keepsats Offset / from_keepsats` (+11,368) and `Treasury Lightning / from_keepsats` (-11,368)
 netting to zero is the intended and correct result.
+
+---
+
+## Fix 4 — Accumulated fractional-msats rounding drift in VSC Liability (May 2026)
+
+**Branch:** `fix/deal-with-residual-rounding-issues`
+
+### Root cause
+
+HIVE/HBD → msats conversions produce a fractional millisatoshi value:
+
+```
+53.999 HIVE × 81.565 sats/HIVE × 1000 = 4,544,449.839963 msats
+```
+
+Before this fix, ledger entries in the `CONV_HIVE_TO_KEEPSATS`, `CONV_CUSTOMER`,
+`CONV_KEEPSATS_TO_HIVE`, `CONSUME_CUSTOMER_KEEPSATS`, and `RECLASSIFY_VSC_SATS`
+flows stored the full-precision fractional value as their `debit_amount` / `credit_amount`.
+The corresponding Lightning Network payments and on-chain keepsats transfers use
+**integer** millisatoshis, so the offsetting ledger entries use an integer amount.
+Each transaction leaves a tiny sub-msat residual in `VSC Liability (v4vapp)` — over
+2,500+ transactions on the live server account this accumulated to **188.23 msats**.
+
+### Changes
+
+| File | Change |
+|---|---|
+| `src/v4vapp_backend_v2/helpers/crypto_conversion.py` | Added `msats_rounded` property to `CryptoConv` (ROUND_HALF_UP to integer Decimal, parallel to existing `sats_rounded`) |
+| `src/v4vapp_backend_v2/conversion/hive_to_keepsats.py` | `CONV_HIVE_TO_KEEPSATS.debit_amount` and `CONV_CUSTOMER.credit_amount` now use `conv.msats_rounded` |
+| `src/v4vapp_backend_v2/conversion/keepsats_to_hive.py` | `CONV_KEEPSATS_TO_HIVE.credit_amount`, `CONSUME_CUSTOMER_KEEPSATS.debit/credit_amount`, and `RECLASSIFY_VSC_SATS.debit/credit_amount` now use `conv.msats_rounded` |
+| `src/v4vapp_backend_v2/models/invoice_models.py` | `update_conv`: `float(amount_msat)` → `int(amount_msat)` |
+| `src/v4vapp_backend_v2/models/payment_models.py` | `update_conv`: `float(fee_msat)` and `float(value_msat + fee_msat)` → `int(...)` |
+
+### Test coverage
+
+New test file: `tests/helpers/test_msats_rounding.py` (17 tests)
+
+- `TestMsatsRoundedProperty` — unit tests for the new property (zero, fractions, integers, large values, return type)
+- `TestCryptoConversionIntegerMsats` — verifies integer MSATS inputs stay integer; HIVE inputs produce fractional; `msats_rounded` eliminates fractional drift; `int()` vs `float()` inputs for LND values
+- `TestAccumulatedRoundingDrift` — simulation tests demonstrating that without rounding the residual grows with transaction count, while with `msats_rounded` it is bounded to ≤ 0.5 msats per transaction
+
+### Remaining residual in historical data
+
+The **188 msats** in the live VSC Liability account as of 2026-05-08 remains as a
+historical artefact. It can be corrected with a manual adjustment ledger entry if
+desired. All **new** transactions from this fix forward will use rounded integer
+msats and will not introduce further fractional drift.
+
+### Why ROUND_HALF_UP (not floor/truncation)
+
+The Lightning Network itself can send any integer msats value — there is no requirement
+to truncate. Using ROUND_HALF_UP is consistent with `sats_rounded` and gives the customer
+the nearest-integer approximation of the calculated value. The residual per transaction
+is bounded to ±0.5 msats (whichever rounding direction is closest), which is negligible
+and symmetric across many transactions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "v4vapp-backend-v2"
-version = "2.8.3"
+version = "2.8.4"
 description = "Back End for the V4V.app bridge from Hive to Lightning"
 authors = [{name = "Brian of London (home imac)", email = "brian@v4v.app"}]
 license = {text = "MIT"}

--- a/src/v4vapp_backend_v2/accounting/account_balances.py
+++ b/src/v4vapp_backend_v2/accounting/account_balances.py
@@ -24,7 +24,11 @@ from v4vapp_backend_v2.accounting.in_progress_results_class import (
     InProgressResults,
     all_held_msats,
 )
-from v4vapp_backend_v2.accounting.ledger_account_classes import LedgerAccount, LiabilityAccount
+from v4vapp_backend_v2.accounting.ledger_account_classes import (
+    AccountType,
+    LedgerAccount,
+    LiabilityAccount,
+)
 from v4vapp_backend_v2.accounting.ledger_cache import (
     HISTORICAL_TTL_SECONDS,
     LIVE_TTL_SECONDS,
@@ -1654,20 +1658,48 @@ async def keepsats_balance(
         sub=cust_id,
         contra=False,
     )
-    # NOTE: we set use_checkpoints=False here to ensure we get the full transaction history needed to compute the balance,
-    async with asyncio.TaskGroup() as task_group:
-        magi_balance_task = task_group.create_task(get_magi_btc_balance_by_account(cust_id))
-        account_balance_task = task_group.create_task(
-            one_account_balance(
-                account=account,
-                as_of_date=as_of_date,
-                age=None,
-                use_checkpoints=True,
+
+    if line_items or notifications:
+        # Full per-transaction history is needed (transactions=True or notifications requested).
+        async with asyncio.TaskGroup() as task_group:
+            magi_balance_task = task_group.create_task(get_magi_btc_balance_by_account(cust_id))
+            account_balance_task = task_group.create_task(
+                one_account_balance(
+                    account=account,
+                    as_of_date=as_of_date,
+                    age=None,
+                    use_checkpoints=True,
+                )
             )
-        )
+        account_balance = account_balance_task.result()
+    else:
+        # Balance-only path (transactions=False): use the lightweight summary aggregation.
+        # all_account_balances_summary runs a simple $group (no O(n) running-total window)
+        # which is significantly faster for high-volume accounts like the operator account.
+        async with asyncio.TaskGroup() as task_group:
+            magi_balance_task = task_group.create_task(get_magi_btc_balance_by_account(cust_id))
+            summary_task = task_group.create_task(
+                all_account_balances_summary(
+                    account_name="VSC Liability",
+                    cust_ids={cust_id},
+                    as_of_date=as_of_date,
+                )
+            )
+        summary = summary_task.result()
+        # Extract the non-contra VSC Liability entry for this customer.
+        # Note: avoid passing a constructed default to next() — it would be
+        # evaluated eagerly even when a match is found.
+        _match = next((a for a in summary.root if a.sub == cust_id and not a.contra), None)
+        if _match is not None:
+            account_balance = _match
+        else:
+            account_balance = LedgerAccountDetails(
+                name="VSC Liability",
+                account_type=AccountType.LIABILITY,
+                sub=cust_id,
+            )
 
     magi_balance = magi_balance_task.result()
-    account_balance = account_balance_task.result()
     account_balance.magi_btc_sats = magi_balance.balance_sats
     account_balance.magi_btc_msats = magi_balance.balance_msats
 

--- a/src/v4vapp_backend_v2/accounting/account_balances.py
+++ b/src/v4vapp_backend_v2/accounting/account_balances.py
@@ -257,24 +257,46 @@ async def all_account_balances_summary(
     results = convert_decimal128_to_decimal(results)
     _t1 = timer()
 
-    # Group rows by (account_type, name, sub, contra) — same grouping as the
-    # full pipeline so contra variants stay separate.
+    # Group rows by (account_type, name, sub), merging contra and non-contra
+    # variants into a single entry — mirroring the merge that one_account_balance
+    # performs after its pipeline.  The contra sign is already baked into
+    # amount_signed / conv_signed by the time the pipeline emits a row, so
+    # summing across contra variants gives the correct net balance.
     account_groups: dict[tuple, dict] = {}
     for row in results:
-        key = (row["account_type"], row["name"], row["sub"], row.get("contra", False))
+        key = (row["account_type"], row["name"], row["sub"])
         if key not in account_groups:
             account_groups[key] = {
                 "account_type": row["account_type"],
                 "name": row["name"],
                 "sub": row["sub"],
-                "contra": row.get("contra", False),
+                "contra": False,  # merged view is always non-contra
                 "units": {},
                 "max_timestamp": None,
                 "total_count": 0,
                 "has_non_opening": False,
             }
         group = account_groups[key]
-        group["units"][row["unit"]] = row
+        unit = row["unit"]
+        if unit in group["units"]:
+            # Accumulate amounts from contra variant into the existing unit row.
+            existing = group["units"][unit]
+            existing["total_amount"] += row["total_amount"]
+            existing["total_conv_hive"] += row["total_conv_hive"]
+            existing["total_conv_hbd"] += row["total_conv_hbd"]
+            existing["total_conv_usd"] += row["total_conv_usd"]
+            existing["total_conv_sats"] += row["total_conv_sats"]
+            existing["total_conv_msats"] += row["total_conv_msats"]
+            existing["count"] = existing.get("count", 0) + row.get("count", 0)
+            if row.get("has_non_opening"):
+                existing["has_non_opening"] = True
+            ts_unit = row.get("max_timestamp")
+            if ts_unit and (
+                existing.get("max_timestamp") is None or ts_unit > existing["max_timestamp"]
+            ):
+                existing["max_timestamp"] = ts_unit
+        else:
+            group["units"][unit] = dict(row)  # copy — we may mutate it above
         ts = row.get("max_timestamp")
         if ts and (group["max_timestamp"] is None or ts > group["max_timestamp"]):
             group["max_timestamp"] = ts

--- a/src/v4vapp_backend_v2/conversion/hive_to_keepsats.py
+++ b/src/v4vapp_backend_v2/conversion/hive_to_keepsats.py
@@ -248,7 +248,7 @@ async def conversion_hive_to_keepsats(
     transfer = KeepsatsTransfer(
         from_account=server_id,
         to_account=cust_id,
-        msats=int(conv_result.to_convert_conv.msats),
+        msats=int(conv_result.to_convert_conv.msats_rounded),
         memo=memo,
         parent_id=tracked_op.group_id,  # This is the group_id of the original transfer
     )

--- a/src/v4vapp_backend_v2/conversion/hive_to_keepsats.py
+++ b/src/v4vapp_backend_v2/conversion/hive_to_keepsats.py
@@ -136,7 +136,7 @@ async def conversion_hive_to_keepsats(
             sub="to_keepsats",
         ),
         debit_unit=Currency.MSATS,
-        debit_amount=conv_result.to_convert_conv.msats,
+        debit_amount=conv_result.to_convert_conv.msats_rounded,
         debit_conv=conv_result.to_convert_conv,
         credit=AssetAccount(
             name="Customer Deposits Hive",
@@ -200,7 +200,7 @@ async def conversion_hive_to_keepsats(
             sub=server_id,  # This is the asset account for the server, where keepsats are held
         ),
         credit_unit=Currency.MSATS,
-        credit_amount=conv_result.to_convert_conv.msats,
+        credit_amount=conv_result.to_convert_conv.msats_rounded,
         credit_conv=conv_result.to_convert_conv,
         link=tracked_op.link,
     )

--- a/src/v4vapp_backend_v2/conversion/keepsats_to_hive.py
+++ b/src/v4vapp_backend_v2/conversion/keepsats_to_hive.py
@@ -172,7 +172,7 @@ async def conversion_keepsats_to_hive(
         debit_conv=conv_result.to_convert_conv,
         credit=AssetAccount(name="Treasury Lightning", sub="from_keepsats"),
         credit_unit=Currency.MSATS,
-        credit_amount=conv_result.to_convert_conv.msats,
+        credit_amount=conv_result.to_convert_conv.msats_rounded,
         credit_conv=conv_result.to_convert_conv,
         link=tracked_op.link,
     )
@@ -282,13 +282,13 @@ async def conversion_keepsats_to_hive(
             description=f"Consume customer SATS for Keepsats-to-{to_currency} conversion {conv_result.net_to_receive_conv.sats_rounded:,.0f} msats for {cust_id}",  # Updated description
             debit=LiabilityAccount(name="VSC Liability", sub=cust_id),
             debit_unit=Currency.MSATS,
-            debit_amount=conv_result.net_to_receive_conv.msats,  # Changed from to_convert_conv.msats to net_to_receive_conv.msats
+            debit_amount=conv_result.net_to_receive_conv.msats_rounded,
             debit_conv=conv_result.net_to_receive_conv,
             credit=AssetAccount(
                 name="Converted Keepsats Offset", sub="from_keepsats", contra=True
             ),
             credit_unit=Currency.MSATS,
-            credit_amount=conv_result.net_to_receive_conv.msats,  # Changed from to_convert_conv.msats to net_to_receive_conv.msats
+            credit_amount=conv_result.net_to_receive_conv.msats_rounded,
             credit_conv=conv_result.net_to_receive_conv,
             link=tracked_op.link,
         )
@@ -341,13 +341,13 @@ async def conversion_keepsats_to_hive(
             description=f"Reclassify positive SATS (net) from VSC {server_id} to Converted Keepsats Offset for Keepsats-to-Hive inflow",
             debit=LiabilityAccount(name="VSC Liability", sub=server_id),
             debit_unit=Currency.MSATS,
-            debit_amount=conv_result.net_to_receive_conv.msats,
+            debit_amount=conv_result.net_to_receive_conv.msats_rounded,
             debit_conv=conv_result.net_to_receive_conv,
             credit=AssetAccount(
                 name="Converted Keepsats Offset", sub="from_keepsats", contra=True
             ),
             credit_unit=Currency.MSATS,
-            credit_amount=conv_result.net_to_receive_conv.msats,
+            credit_amount=conv_result.net_to_receive_conv.msats_rounded,
             credit_conv=conv_result.net_to_receive_conv,
             link=tracked_op.link,
         )

--- a/src/v4vapp_backend_v2/conversion/keepsats_to_hive.py
+++ b/src/v4vapp_backend_v2/conversion/keepsats_to_hive.py
@@ -279,7 +279,7 @@ async def conversion_keepsats_to_hive(
             ledger_type=ledger_type,
             group_id=f"{tracked_op.group_id}_{ledger_type.value}",
             timestamp=datetime.now(tz=timezone.utc),
-            description=f"Consume customer SATS for Keepsats-to-{to_currency} conversion {conv_result.net_to_receive_conv.sats_rounded:,.0f} msats for {cust_id}",  # Updated description
+            description=f"Consume customer SATS for Keepsats-to-{to_currency} conversion {conv_result.net_to_receive_conv.sats_rounded:,.0f} sats for {cust_id}",  # Updated description
             debit=LiabilityAccount(name="VSC Liability", sub=cust_id),
             debit_unit=Currency.MSATS,
             debit_amount=conv_result.net_to_receive_conv.msats_rounded,

--- a/src/v4vapp_backend_v2/helpers/crypto_conversion.py
+++ b/src/v4vapp_backend_v2/helpers/crypto_conversion.py
@@ -72,6 +72,23 @@ class CryptoConv(BaseModel):
         """
         return self.sats.quantize(Decimal("1"), rounding=ROUND_HALF_UP)
 
+    @property
+    def msats_rounded(self) -> Decimal:
+        """
+        Round msats to the nearest integer using standard rounding (ROUND_HALF_UP).
+
+        This is the canonical value to use in ledger entries for msats amounts that
+        correspond to actual Lightning Network payments, which are always integer msats.
+        Using the full-precision fractional value (e.g. 4544449.839963) instead of an
+        integer causes accumulated sub-msat rounding drift across many transactions.
+
+        Examples:
+        - 4544449.2 -> 4544449
+        - 4544449.5 -> 4544450  (rounds UP)
+        - 4544449.839963 -> 4544450
+        """
+        return self.msats.quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+
     @field_validator(
         "hive",
         "hbd",

--- a/src/v4vapp_backend_v2/models/invoice_models.py
+++ b/src/v4vapp_backend_v2/models/invoice_models.py
@@ -305,7 +305,7 @@ class Invoice(TrackedBaseModel):
 
         self.conv = CryptoConversion(
             conv_from=Currency.MSATS,
-            value=float(amount_msat),
+            value=int(amount_msat),
             quote=quote,
         ).conversion
 

--- a/src/v4vapp_backend_v2/models/payment_models.py
+++ b/src/v4vapp_backend_v2/models/payment_models.py
@@ -177,12 +177,12 @@ class Payment(TrackedBaseModel):
         if self.fee_msat:
             self.fee_conv = CryptoConversion(
                 conv_from=Currency.MSATS,
-                value=float(self.fee_msat),
+                value=int(self.fee_msat),
                 quote=quote,
             ).conversion
         self.conv = CryptoConversion(
             conv_from=Currency.MSATS,
-            value=float(self.value_msat + self.fee_msat),
+            value=int(self.value_msat + self.fee_msat),
             quote=quote,
         ).conversion
 
@@ -302,16 +302,14 @@ class Payment(TrackedBaseModel):
             return "Unknown"
 
         route_fees_ppm = self.route_fees_ppm
-        ans = " -> ".join(
-            [
-                (
-                    f"{hop.alias}"
-                    if route_fees_ppm.get(hop.pub_key) is None
-                    else f"{hop.alias} ({route_fees_ppm.get(hop.pub_key):.0f} ppm)"
-                )
-                for hop in self.route
-            ]
-        )
+        ans = " -> ".join([
+            (
+                f"{hop.alias}"
+                if route_fees_ppm.get(hop.pub_key) is None
+                else f"{hop.alias} ({route_fees_ppm.get(hop.pub_key):.0f} ppm)"
+            )
+            for hop in self.route
+        ])
         return ans
 
     # Methods from Payment

--- a/tests/accounting/test_account_balances.py
+++ b/tests/accounting/test_account_balances.py
@@ -87,21 +87,19 @@ async def load_ledger_events():
 
     # Add a notification record for the test customer so we can validate that
     # keepsats_balance correctly includes notification history when requested.
-    await InternalConfig.db["hive_ops"].insert_one(
-        {
-            "cust_id": "v4vapp.qrc",
-            "trx_id": "testtrxid123",
-            "short_id": "0000_test",
-            "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc),
-            "json": {
-                "notification": True,
-                "memo": "Test notification",
-                "parent_id": "parent123",
-                "hive_accname_to": "v4vapp.qrc",
-                "hive_accname_from": "devser.v4vapp",
-            },
-        }
-    )
+    await InternalConfig.db["hive_ops"].insert_one({
+        "cust_id": "v4vapp.qrc",
+        "trx_id": "testtrxid123",
+        "short_id": "0000_test",
+        "timestamp": datetime(2026, 1, 1, tzinfo=timezone.utc),
+        "json": {
+            "notification": True,
+            "memo": "Test notification",
+            "parent_id": "parent123",
+            "hive_accname_to": "v4vapp.qrc",
+            "hive_accname_from": "devser.v4vapp",
+        },
+    })
 
 
 async def test_list_all_accounts():
@@ -285,40 +283,64 @@ async def test_all_account_balances():
 
 
 async def test_all_account_balances_summary():
-    """Test that the summary function produces the same final totals as the full pipeline."""
+    """Test that the summary function produces the same final totals as the full pipeline.
+
+    all_account_balances_summary merges contra and non-contra groups for each
+    (account_type, name, sub) into a single entry (contra=False) so that the net
+    balance is correct.  The full pipeline returns them separately; we build a merged
+    view of the full results using the same key before comparing.
+    """
     full = await all_account_balances()
     summary = await all_account_balances_summary()
 
     assert isinstance(summary, AccountBalances)
     assert len(summary.root) > 0
 
-    # Build lookup from the full results keyed by (account_type, name, sub, contra)
-    full_map = {(a.account_type, a.name, a.sub, a.contra): a for a in full.root}
+    # Merge full results by (account_type, name, sub) — same as the summary does —
+    # so contra and non-contra variants are summed before comparison.
+    from decimal import Decimal as _D
+
+    full_merged: dict[tuple, dict] = {}
+    for a in full.root:
+        key = (a.account_type, a.name, a.sub)
+        if key not in full_merged:
+            full_merged[key] = {
+                "sats": _D(0),
+                "msats": _D(0),
+                "hive": _D(0),
+                "hbd": _D(0),
+                "conv_usd": _D(0),
+                "conv_sats": _D(0),
+            }
+        m = full_merged[key]
+        m["sats"] += a.sats
+        m["msats"] += a.msats
+        m["hive"] += a.hive
+        m["hbd"] += a.hbd
+        m["conv_usd"] += a.conv_total.usd
+        m["conv_sats"] += a.conv_total.sats
 
     for s_acct in summary.root:
-        key = (s_acct.account_type, s_acct.name, s_acct.sub, s_acct.contra)
-        f_acct = full_map.get(key)
-        assert f_acct is not None, f"Summary account {key} not found in full results"
+        key = (s_acct.account_type, s_acct.name, s_acct.sub)
+        f = full_merged.get(key)
+        assert f is not None, f"Summary account {key} not found in full results"
 
-        # Final balances must match
-        assert s_acct.sats == f_acct.sats, (
-            f"sats mismatch for {key}: summary={s_acct.sats} full={f_acct.sats}"
+        assert s_acct.sats == f["sats"], (
+            f"sats mismatch for {key}: summary={s_acct.sats} full={f['sats']}"
         )
-        assert s_acct.msats == f_acct.msats, (
-            f"msats mismatch for {key}: summary={s_acct.msats} full={f_acct.msats}"
+        assert s_acct.msats == f["msats"], (
+            f"msats mismatch for {key}: summary={s_acct.msats} full={f['msats']}"
         )
-        assert abs(s_acct.hive - f_acct.hive) <= Decimal("0.001"), (
-            f"hive mismatch for {key}: summary={s_acct.hive} full={f_acct.hive}"
+        assert abs(s_acct.hive - f["hive"]) <= Decimal("0.001"), (
+            f"hive mismatch for {key}: summary={s_acct.hive} full={f['hive']}"
         )
-        assert abs(s_acct.hbd - f_acct.hbd) <= Decimal("0.001"), (
-            f"hbd mismatch for {key}: summary={s_acct.hbd} full={f_acct.hbd}"
+        assert abs(s_acct.hbd - f["hbd"]) <= Decimal("0.001"), (
+            f"hbd mismatch for {key}: summary={s_acct.hbd} full={f['hbd']}"
         )
-
-        # Converted totals should match within tolerance
-        assert abs(s_acct.conv_total.usd - f_acct.conv_total.usd) <= Decimal("0.01"), (
+        assert abs(s_acct.conv_total.usd - f["conv_usd"]) <= Decimal("0.01"), (
             f"conv_total.usd mismatch for {key}"
         )
-        assert abs(s_acct.conv_total.sats - f_acct.conv_total.sats) <= Decimal("1"), (
+        assert abs(s_acct.conv_total.sats - f["conv_sats"]) <= Decimal("1"), (
             f"conv_total.sats mismatch for {key}"
         )
 

--- a/tests/accounting/test_summary_vs_full_production.py
+++ b/tests/accounting/test_summary_vs_full_production.py
@@ -1,0 +1,390 @@
+"""
+Production-only test: verify that `all_account_balances_summary` returns the same
+msats/hive/hbd totals as `one_account_balance` for the accounts used by the
+dashboard and sanity checks.
+
+Run locally against the production (or staging) database:
+
+    uv run pytest tests/accounting/test_summary_vs_full_production.py -v -s \
+        --config-file production.fromhome.config.yaml
+
+This test is automatically SKIPPED in GitHub Actions (GITHUB_ACTIONS env var set)
+and when the production config file does not exist on disk.
+
+Accounts checked
+----------------
+The following accounts are fetched by the dashboard / sanity checks today and
+only need final-balance totals (no per-transaction running history):
+
+  VSC Liability / sub=<server_id>     (keepsats_balance with line_items=False)
+  VSC Liability / sub="keepsats"      (server_account_balances sanity check)
+  External Lightning Payments / sub=<node_name>  (dashboard lnd_info)
+  Treasury Lightning / sub=<node_name>           (dashboard lnd_info)
+  Customer Deposits Hive / sub=<server_id>       (server_account_hive_balances)
+  Traded Deposits Hive / sub=<server_id>         (server_account_hive_balances)
+"""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip guard — must be evaluated before any imports that touch the config
+# ---------------------------------------------------------------------------
+
+PRODUCTION_CONFIG = "production.fromhome.config.yaml"
+PRODUCTION_CONFIG_PATH = Path("config") / PRODUCTION_CONFIG
+
+_in_ci = os.getenv("GITHUB_ACTIONS") == "true"
+_config_missing = not PRODUCTION_CONFIG_PATH.exists()
+
+pytestmark = pytest.mark.skipif(
+    _in_ci or _config_missing,
+    reason=(
+        "Production-data test skipped in CI or when production config is absent. "
+        f"Looked for: {PRODUCTION_CONFIG_PATH}"
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — set up InternalConfig against production DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def module_monkeypatch():
+    from _pytest.monkeypatch import MonkeyPatch
+
+    mp = MonkeyPatch()
+    yield mp
+    mp.undo()
+
+
+@pytest.fixture(autouse=True, scope="module")
+async def production_config(module_monkeypatch):
+    """Point InternalConfig at the production config file and connect to its DB."""
+    from v4vapp_backend_v2.config.setup import InternalConfig
+    from v4vapp_backend_v2.database.db_pymongo import DBConn
+
+    module_monkeypatch.setattr("v4vapp_backend_v2.config.setup.InternalConfig._instance", None)
+    cfg = InternalConfig(config_filename=PRODUCTION_CONFIG)
+    print(f"\nConnected to production config: {cfg.server_id} / node={cfg.node_name}")
+    db = DBConn()
+    await db.setup_database()
+    yield cfg
+    module_monkeypatch.setattr("v4vapp_backend_v2.config.setup.InternalConfig._instance", None)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Tolerance in msats — summary and full pipelines may differ by a tiny amount
+# due to Decimal128 ↔ Decimal conversion in different code paths.
+MSATS_TOLERANCE = Decimal("1")
+HIVE_TOLERANCE = Decimal("0.001")
+
+
+def _msats_from_summary(summary, sub: str, account_name: str) -> Decimal:
+    """Return the MSATS total for a (name, sub) pair from an AccountBalances summary."""
+    match = next(
+        (a for a in summary.root if a.name == account_name and a.sub == sub and not a.contra),
+        None,
+    )
+    if match is None:
+        return Decimal("0")
+    return match.msats
+
+
+def _hive_from_summary(summary, sub: str, account_name: str) -> Decimal:
+    match = next(
+        (a for a in summary.root if a.name == account_name and a.sub == sub and not a.contra),
+        None,
+    )
+    return match.hive if match else Decimal("0")
+
+
+def _hbd_from_summary(summary, sub: str, account_name: str) -> Decimal:
+    match = next(
+        (a for a in summary.root if a.name == account_name and a.sub == sub and not a.contra),
+        None,
+    )
+    return match.hbd if match else Decimal("0")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_vsc_liability_server_id_msats_match(production_config):
+    """
+    all_account_balances_summary should return the same msats as one_account_balance
+    for VSC Liability / <server_id> — the account used by keepsats_balance(line_items=False).
+
+    Two variants are checked:
+    - Raw (no checkpoints): pure pipeline correctness.
+    - With fresh checkpoint: validates the production keepsats_balance() code path.
+    """
+    from v4vapp_backend_v2.accounting.ledger_account_classes import LiabilityAccount
+
+    server_id = production_config.server_id
+    account = LiabilityAccount(name="VSC Liability", sub=server_id)
+
+    # --- raw comparison (apples-to-apples) ---
+    full_raw, summary = await _fetch_both_raw(account, server_id, "VSC Liability")
+    diff_raw = abs(full_raw.msats - summary.msats)
+    print(
+        f"\nVSC Liability ({server_id}) [raw]:"
+        f"\n  full.msats    = {full_raw.msats}"
+        f"\n  summary.msats = {summary.msats}"
+        f"\n  diff          = {diff_raw}"
+    )
+    assert diff_raw <= MSATS_TOLERANCE, (
+        f"raw msats mismatch for VSC Liability/{server_id}: full={full_raw.msats}, summary={summary.msats}"
+    )
+
+    # --- checkpoint comparison (matches keepsats_balance() production path) ---
+    full_ckpt, summary_ckpt = await _fetch_both_with_checkpoint(
+        account, server_id, "VSC Liability"
+    )
+    diff_ckpt = abs(full_ckpt.msats - summary_ckpt.msats)
+    print(
+        f"\nVSC Liability ({server_id}) [checkpoint]:"
+        f"\n  full.msats    = {full_ckpt.msats}"
+        f"\n  summary.msats = {summary_ckpt.msats}"
+        f"\n  diff          = {diff_ckpt}"
+    )
+    assert diff_ckpt <= MSATS_TOLERANCE, (
+        f"checkpoint msats mismatch for VSC Liability/{server_id}: full={full_ckpt.msats}, summary={summary_ckpt.msats}"
+    )
+
+
+async def test_vsc_liability_keepsats_msats_match(production_config):
+    """
+    VSC Liability / keepsats — used by the server_account_balances sanity check.
+    Both raw and checkpoint variants are checked.
+    """
+    from v4vapp_backend_v2.accounting.ledger_account_classes import LiabilityAccount
+
+    account = LiabilityAccount(name="VSC Liability", sub="keepsats")
+
+    full_raw, summary = await _fetch_both_raw(account, "keepsats", "VSC Liability")
+    diff_raw = abs(full_raw.msats - summary.msats)
+    print(
+        f"\nVSC Liability (keepsats) [raw]:"
+        f"\n  full.msats    = {full_raw.msats}"
+        f"\n  summary.msats = {summary.msats}"
+        f"\n  diff          = {diff_raw}"
+    )
+    assert diff_raw <= MSATS_TOLERANCE, (
+        f"raw msats mismatch for VSC Liability/keepsats: full={full_raw.msats}, summary={summary.msats}"
+    )
+
+    full_ckpt, summary_ckpt = await _fetch_both_with_checkpoint(
+        account, "keepsats", "VSC Liability"
+    )
+    diff_ckpt = abs(full_ckpt.msats - summary_ckpt.msats)
+    print(
+        f"\nVSC Liability (keepsats) [checkpoint]:"
+        f"\n  full.msats    = {full_ckpt.msats}"
+        f"\n  summary.msats = {summary_ckpt.msats}"
+        f"\n  diff          = {diff_ckpt}"
+    )
+    assert diff_ckpt <= MSATS_TOLERANCE, (
+        f"checkpoint msats mismatch for VSC Liability/keepsats: full={full_ckpt.msats}, summary={summary_ckpt.msats}"
+    )
+
+
+async def test_external_lightning_payments_msats_match(production_config):
+    """
+    External Lightning Payments — raw-sum comparison.
+
+    The summary pipeline groups entries by (account_type, name, sub, contra, unit).
+    For asset accounts like External Lightning Payments, there are both contra=True
+    and contra=False entries.  all_account_balances_summary now merges them into a
+    single non-contra entry (same as one_account_balance), so summary == full.
+    """
+    from v4vapp_backend_v2.accounting.ledger_account_classes import AssetAccount
+
+    node_name = production_config.node_name
+    account = AssetAccount(name="External Lightning Payments", sub=node_name)
+    full, summary = await _fetch_both_raw(account, node_name, "External Lightning Payments")
+
+    diff = abs(full.msats - summary.msats)
+    print(
+        f"\nExternal Lightning Payments ({node_name}) [raw]:"
+        f"\n  full.msats    = {full.msats}"
+        f"\n  summary.msats = {summary.msats}"
+        f"\n  diff          = {diff}"
+    )
+    assert diff <= MSATS_TOLERANCE, (
+        f"raw msats mismatch for External Lightning Payments/{node_name}: full={full.msats}, summary={summary.msats}"
+    )
+
+
+async def test_treasury_lightning_msats_match(production_config):
+    """
+    Treasury Lightning — raw-sum comparison.
+
+    Unlike External Lightning Payments, the all_cust_ids field IS consistently populated
+    for Treasury Lightning entries, so the summary pipeline matches the full pipeline.
+    """
+    from v4vapp_backend_v2.accounting.ledger_account_classes import AssetAccount
+
+    node_name = production_config.node_name
+    account = AssetAccount(name="Treasury Lightning", sub=node_name)
+    full, summary = await _fetch_both_raw(account, node_name, "Treasury Lightning")
+
+    diff = abs(full.msats - summary.msats)
+    print(
+        f"\nTreasury Lightning ({node_name}) [raw]:"
+        f"\n  full.msats    = {full.msats}"
+        f"\n  summary.msats = {summary.msats}"
+        f"\n  diff          = {diff}"
+    )
+    assert diff <= MSATS_TOLERANCE, (
+        f"raw msats mismatch for Treasury Lightning/{node_name}: full={full.msats}, summary={summary.msats}"
+    )
+
+
+async def test_customer_deposits_hive_balances_match(production_config):
+    """
+    Customer Deposits Hive — used by server_account_hive_balances sanity check.
+    Needs .hive and .hbd totals only.  Raw-sum comparison.
+    """
+    from v4vapp_backend_v2.accounting.ledger_account_classes import AssetAccount
+
+    server_id = production_config.server_id
+    account = AssetAccount(name="Customer Deposits Hive", sub=server_id)
+    full, summary = await _fetch_both_raw(account, server_id, "Customer Deposits Hive")
+
+    hive_diff = abs(full.hive - summary.hive)
+    hbd_diff = abs(full.hbd - summary.hbd)
+    print(
+        f"\nCustomer Deposits Hive ({server_id}):"
+        f"\n  full.hive={full.hive}, summary.hive={summary.hive}, diff={hive_diff}"
+        f"\n  full.hbd={full.hbd},  summary.hbd={summary.hbd},  diff={hbd_diff}"
+    )
+    assert hive_diff <= HIVE_TOLERANCE, (
+        f"HIVE mismatch for Customer Deposits Hive/{server_id}: full={full.hive}, summary={summary.hive}"
+    )
+    assert hbd_diff <= HIVE_TOLERANCE, (
+        f"HBD mismatch for Customer Deposits Hive/{server_id}: full={full.hbd}, summary={summary.hbd}"
+    )
+
+
+async def test_traded_deposits_hive_balances_match(production_config):
+    """
+    Traded Deposits Hive — used by server_account_hive_balances sanity check.
+    Raw-sum comparison.
+    """
+    from v4vapp_backend_v2.accounting.ledger_account_classes import AssetAccount
+
+    server_id = production_config.server_id
+    account = AssetAccount(name="Traded Deposits Hive", sub=server_id)
+    full, summary = await _fetch_both_raw(account, server_id, "Traded Deposits Hive")
+
+    hive_diff = abs(full.hive - summary.hive)
+    hbd_diff = abs(full.hbd - summary.hbd)
+    print(
+        f"\nTraded Deposits Hive ({server_id}):"
+        f"\n  full.hive={full.hive}, summary.hive={summary.hive}, diff={hive_diff}"
+        f"\n  full.hbd={full.hbd},  summary.hbd={summary.hbd},  diff={hbd_diff}"
+    )
+    assert hive_diff <= HIVE_TOLERANCE, (
+        f"HIVE mismatch for Traded Deposits Hive/{server_id}: full={full.hive}, summary={summary.hive}"
+    )
+    assert hbd_diff <= HIVE_TOLERANCE, (
+        f"HBD mismatch for Traded Deposits Hive/{server_id}: full={full.hbd}, summary={summary.hbd}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_both_raw(account, sub, account_name):
+    """
+    Compare all_account_balances_summary against one_account_balance(use_checkpoints=False).
+
+    This is an apples-to-apples comparison: both pipelines do a raw full-history sum
+    without checkpoints.  Use this to verify pipeline correctness independent of
+    whether checkpoint data is fresh.
+    """
+    import asyncio
+
+    from v4vapp_backend_v2.accounting.account_balances import (
+        all_account_balances_summary,
+        one_account_balance,
+    )
+
+    async with asyncio.TaskGroup() as tg:
+        full_task = tg.create_task(
+            one_account_balance(account=account, use_cache=False, use_checkpoints=False)
+        )
+        summary_task = tg.create_task(
+            all_account_balances_summary(account_name=account_name, cust_ids={sub})
+        )
+
+    full = full_task.result()
+    summary_result = summary_task.result()
+    summary_match = _extract_summary(summary_result, sub, account_name)
+    return full, summary_match
+
+
+async def _fetch_both_with_checkpoint(account, sub, account_name):
+    """
+    Compare all_account_balances_summary against one_account_balance(use_checkpoints=True).
+
+    Ensures the checkpoint is fresh first (matching what sanity_checks.py does) then
+    compares.  This validates that the summary path agrees with the production
+    checkpoint-accelerated path.
+    """
+    import asyncio
+
+    from v4vapp_backend_v2.accounting.account_balances import (
+        all_account_balances_summary,
+        one_account_balance,
+    )
+    from v4vapp_backend_v2.accounting.ledger_checkpoints import (
+        PeriodType,
+        latest_period_create_checkpoint,
+    )
+
+    await latest_period_create_checkpoint(account=account, period_type=PeriodType.DAILY)
+
+    async with asyncio.TaskGroup() as tg:
+        full_task = tg.create_task(
+            one_account_balance(account=account, use_cache=False, use_checkpoints=True)
+        )
+        summary_task = tg.create_task(
+            all_account_balances_summary(account_name=account_name, cust_ids={sub})
+        )
+
+    full = full_task.result()
+    summary_result = summary_task.result()
+    summary_match = _extract_summary(summary_result, sub, account_name)
+    return full, summary_match
+
+
+def _extract_summary(summary_result, sub, account_name):
+    """Extract the non-contra LedgerAccountDetails for (account_name, sub) from an AccountBalances."""
+    from v4vapp_backend_v2.accounting.accounting_classes import LedgerAccountDetails
+    from v4vapp_backend_v2.accounting.ledger_account_classes import AccountType
+
+    match = next(
+        (a for a in summary_result.root if a.sub == sub and not a.contra), None
+    )
+    if match is None:
+        return LedgerAccountDetails(
+            name=account_name,
+            account_type=AccountType.LIABILITY,
+            sub=sub,
+        )
+    return match

--- a/tests/helpers/test_msats_rounding.py
+++ b/tests/helpers/test_msats_rounding.py
@@ -183,8 +183,12 @@ class TestAccumulatedRoundingDrift:
 
     def _simulate_transactions(self, use_rounded: bool) -> Decimal:
         """
-        For each HIVE amount, compute the cust_conv ledger credit and the
-        corresponding Lightning send (which uses integer msats = floor of fractional).
+        For each HIVE amount, compute the ledger credit and the Lightning transfer.
+
+        use_rounded=False (old code): ledger used msats_rounded, transfer used
+            int(msats) i.e. floor — so residual = credit_rounded - floor(msats).
+        use_rounded=True (fixed code): both ledger AND transfer use msats_rounded,
+            so residual = 0 per transaction.
 
         Returns the accumulated residual: sum(credit - debit).
         """
@@ -196,38 +200,39 @@ class TestAccumulatedRoundingDrift:
                 value=Decimal(amount_str), conv_from=Currency.HIVE, quote=quote
             ).conversion
 
-            # cust_conv ledger credit: fractional or rounded
-            credit = conv.msats_rounded if use_rounded else conv.msats
+            if use_rounded:
+                # Fixed code: both ledger and transfer use msats_rounded
+                credit = conv.msats_rounded
+                lightning_send = conv.msats_rounded  # int(msats_rounded) in code
+            else:
+                # Old code: ledger used msats_rounded, transfer used int(msats) = floor
+                credit = conv.msats_rounded
+                lightning_send = conv.msats.to_integral_value(rounding="ROUND_FLOOR")
 
-            # Lightning payment always truncates to integer msats (floor)
-            lightning_send = conv.msats.to_integral_value(rounding="ROUND_FLOOR")
-
-            # Running total per transaction: credit - debit
             total_residual += credit - lightning_send
 
         return total_residual
 
     def test_without_rounding_residual_accumulates(self):
-        """Without rounding, fractional msats accumulate across transactions."""
-        residual = self._simulate_transactions(use_rounded=False)
-        # The residual should be the sum of fractional parts (all positive)
-        assert residual > 0, "Expected positive drift from unrounded ledger entries"
-        # It should be clearly sub-msat in total (each fraction is < 1 msat)
-        assert residual < len(self.HIVE_AMOUNTS), "Residual bounded by transaction count"
-
-    def test_with_msats_rounded_residual_bounded_to_half_msat_per_tx(self):
         """
-        With msats_rounded (ROUND_HALF_UP), the residual per transaction is
-        at most ±0.5 msats.  Over N transactions the maximum accumulated drift
-        is N/2 msats — dramatically smaller than the unrounded case.
+        Old code: ledger used msats_rounded but transfer used int(msats) = floor.
+        The per-tx residual is credit_rounded - floor(msats), which is 0 or +1 msat.
+        Over N transactions the maximum drift is N msats (one per tx when fraction >= 0.5).
         """
-        quote = make_quote(sats_per_hive="81.565")
         n = len(self.HIVE_AMOUNTS)
-        max_expected = Decimal(n) * Decimal("0.5")
+        residual = self._simulate_transactions(use_rounded=False)
+        # Residual is non-negative (rounded >= floor always) and at most N
+        assert residual >= 0, "Expected non-negative drift from floor transfer"
+        assert residual <= n, f"Residual {residual} exceeds max possible {n}"
 
+    def test_with_msats_rounded_residual_is_zero(self):
+        """
+        Fixed code: both the ledger credit AND the Lightning transfer use msats_rounded.
+        credit == debit per transaction → accumulated residual is exactly 0.
+        """
         residual = self._simulate_transactions(use_rounded=True)
-        assert abs(residual) <= max_expected, (
-            f"Rounded residual {residual} exceeds expected max {max_expected}"
+        assert residual == Decimal("0"), (
+            f"Expected zero residual when both sides use msats_rounded, got {residual}"
         )
 
     def test_large_scale_unrounded_drift_grows_linearly(self):
@@ -244,19 +249,21 @@ class TestAccumulatedRoundingDrift:
         # should be at least 10 msats (clearly non-trivial).
         assert drift > Decimal("10"), "Expected drift > 10 msats for 100 identical transactions"
 
-    def test_large_scale_rounded_drift_stays_bounded(self):
-        """With msats_rounded, drift over 100 identical transactions stays near zero."""
+    def test_large_scale_rounded_drift_is_zero(self):
+        """
+        Fixed code: both ledger and transfer use msats_rounded.
+        Over 100 identical transactions the drift is exactly 0.
+        """
         quote = make_quote(sats_per_hive="81.565")
         amounts = [Decimal("53.999")] * 100
         drift = Decimal("0")
         for amt in amounts:
             conv = CryptoConversion(value=amt, conv_from=Currency.HIVE, quote=quote).conversion
-            # Rounded credit vs floor debit
+            # Both ledger and transfer use the same rounded value → zero residual
             credit = conv.msats_rounded
-            debit = conv.msats.to_integral_value(rounding="ROUND_FLOOR")
+            debit = conv.msats_rounded
             drift += credit - debit
 
-        # With ROUND_HALF_UP: 4544449.839963 → rounded up → credit=4544450, debit=4544449
-        # Each tx contributes +1 msat; total over 100 = +100 msats.
-        # This is still vastly better than the unrounded ~+84 msats per transaction × 100.
-        assert abs(drift) <= 100, f"Per-transaction residual with rounding: {drift / 100} msats"
+        assert drift == Decimal("0"), (
+            f"Expected zero drift when both sides use msats_rounded, got {drift}"
+        )

--- a/tests/helpers/test_msats_rounding.py
+++ b/tests/helpers/test_msats_rounding.py
@@ -1,0 +1,262 @@
+"""
+Tests for the msats_rounded property on CryptoConv and the use of integer msats
+in ledger entries created during HIVE/HBD → keepsats conversions.
+
+Background
+----------
+When converting HIVE/HBD to millisatoshis the full-precision computation produces
+a fractional msats value, e.g.
+
+    53.999 HIVE × 81.565 sats/HIVE × 1000 = 4,544,449.839963 msats
+
+The corresponding Lightning Network payment is always an integer number of msats
+(e.g. 4,544,449 msats).  Recording the fractional value in ledger entries while
+the actual movement is an integer leaves a sub-msat residual per transaction that
+accumulates over thousands of conversions.
+
+The fix is to use `CryptoConv.msats_rounded` (ROUND_HALF_UP to integer) whenever
+writing msats amounts to ledger entries that correspond to real Lightning payments.
+"""
+
+from decimal import Decimal
+
+from v4vapp_backend_v2.helpers.crypto_conversion import CryptoConv, CryptoConversion
+from v4vapp_backend_v2.helpers.crypto_prices import QuoteResponse
+from v4vapp_backend_v2.helpers.currency_class import Currency
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_quote(sats_per_hive: str = "81.565") -> QuoteResponse:
+    """Return a minimal QuoteResponse with a known HIVE→sats rate."""
+    hive_usd = Decimal("0.3")
+    btc_usd = Decimal("60000")
+    # sats_per_hive = hive_usd / btc_usd * 1e8 → we directly inject via hive_usd
+    # Use a known btc_usd that yields the desired rate: sats_hive_p ≈ hive_usd/btc_usd*1e8
+    # hive_usd = sats_per_hive * btc_usd / 1e8
+    target_sats = Decimal(sats_per_hive)
+    derived_hive_usd = target_sats * btc_usd / Decimal("1e8")
+    return QuoteResponse(hive_usd=derived_hive_usd, btc_usd=btc_usd)
+
+
+# ---------------------------------------------------------------------------
+# msats_rounded property
+# ---------------------------------------------------------------------------
+
+
+class TestMsatsRoundedProperty:
+    """Unit tests for CryptoConv.msats_rounded."""
+
+    def test_integer_msats_unchanged(self):
+        """An already-integer msats value stays unchanged after rounding."""
+        conv = CryptoConv(msats=Decimal("4408000"))
+        assert conv.msats_rounded == Decimal("4408000")
+        assert conv.msats_rounded == conv.msats
+
+    def test_fraction_below_half_rounds_down(self):
+        """0.4 fractional part rounds DOWN to the integer below."""
+        conv = CryptoConv(msats=Decimal("4544449.4"))
+        assert conv.msats_rounded == Decimal("4544449")
+
+    def test_fraction_exactly_half_rounds_up(self):
+        """0.5 fractional part rounds UP (ROUND_HALF_UP, not banker's rounding)."""
+        conv = CryptoConv(msats=Decimal("4544449.5"))
+        assert conv.msats_rounded == Decimal("4544450")
+
+    def test_fraction_above_half_rounds_up(self):
+        """0.839963 fractional part rounds UP."""
+        conv = CryptoConv(msats=Decimal("4544449.839963"))
+        assert conv.msats_rounded == Decimal("4544450")
+
+    def test_return_type_is_decimal(self):
+        """msats_rounded returns a Decimal, not int or float."""
+        conv = CryptoConv(msats=Decimal("1234567.9"))
+        result = conv.msats_rounded
+        assert isinstance(result, Decimal)
+
+    def test_result_has_no_fractional_part(self):
+        """msats_rounded always has exponent >= 0 (no decimal digits)."""
+        for value in ("0.001", "999.999", "1000000.123456789", "0.5"):
+            conv = CryptoConv(msats=Decimal(value))
+            assert conv.msats_rounded % 1 == 0, f"Non-integer result for msats={value}"
+
+    def test_zero_msats(self):
+        """Zero msats stays zero."""
+        conv = CryptoConv(msats=Decimal("0"))
+        assert conv.msats_rounded == Decimal("0")
+
+    def test_large_value_precision_preserved(self):
+        """Values close to 2^53 (the float precision boundary) are handled correctly."""
+        large = Decimal("9007199254740992")  # 2^53, exact in float
+        conv = CryptoConv(msats=large + Decimal("0.5"))
+        # ROUND_HALF_UP → should round up
+        assert conv.msats_rounded == large + 1
+
+    def test_consistent_with_sats_rounded(self):
+        """msats_rounded == sats_rounded * 1000 when sats are < 0.5 away from the integer."""
+        # Build a conv where sats = 4544.449839963
+        # sats_rounded = 4544, msats_rounded should = 4544450 (NOT 4544*1000=4544000)
+        # They are independent roundings; both should be ROUND_HALF_UP integers.
+        conv = CryptoConv(msats=Decimal("4544449.839963"))
+        assert conv.msats_rounded == Decimal("4544450")
+        assert conv.sats_rounded == Decimal("4544")
+
+
+# ---------------------------------------------------------------------------
+# CryptoConversion produces integer msats when input is integer MSATS
+# ---------------------------------------------------------------------------
+
+
+class TestCryptoConversionIntegerMsats:
+    """Verify CryptoConversion preserves integer msats for LND-sourced values."""
+
+    def test_integer_msat_input_gives_integer_msats(self):
+        """When conv_from is MSATS and value is an integer, msats stays integer."""
+        quote = make_quote()
+        conv = CryptoConversion(value=4_408_000, conv_from=Currency.MSATS, quote=quote)
+        # msats should be exactly the integer input (no fractional drift)
+        assert conv.msats % 1 == 0
+        assert conv.msats == Decimal("4408000")
+
+    def test_hive_to_msats_produces_fractional(self):
+        """Converting from HIVE to MSATS with a non-round rate produces fractional msats."""
+        quote = make_quote(sats_per_hive="81.565")
+        # 53.999 HIVE at 81.565 sats/HIVE → 4,544,449.839... msats
+        conv = CryptoConversion(value=Decimal("53.999"), conv_from=Currency.HIVE, quote=quote)
+        assert conv.msats % 1 != 0, "Expected fractional msats from HIVE conversion"
+
+    def test_msats_rounded_eliminates_fractional_drift(self):
+        """
+        msats_rounded on the result of a HIVE→MSATS conversion is an integer,
+        eliminating the sub-msat residual that accumulates in the VSC Liability account.
+        """
+        quote = make_quote(sats_per_hive="81.565")
+        conv = CryptoConversion(value=Decimal("53.999"), conv_from=Currency.HIVE, quote=quote)
+        result = conv.conversion
+        assert result.msats % 1 != 0, "pre-condition: full-precision msats is fractional"
+        assert result.msats_rounded % 1 == 0, "post-fix: msats_rounded is integer"
+
+    def test_int_value_in_update_conv_gives_integer_msats(self):
+        """Using int() instead of float() for LND msat inputs preserves integer precision."""
+        quote = make_quote()
+        lnd_msat_value = 4_408_000  # integer from LND gRPC
+        # Previously: float(lnd_msat_value) — could silently introduce float imprecision
+        # Now: int(lnd_msat_value)
+        conv_int = CryptoConversion(
+            value=int(lnd_msat_value), conv_from=Currency.MSATS, quote=quote
+        )
+        conv_float = CryptoConversion(
+            value=float(lnd_msat_value), conv_from=Currency.MSATS, quote=quote
+        )
+        # For integer LND values < 2^53, int and float both give the same result.
+        # Crucially, using int avoids silent precision loss for callers.
+        assert conv_int.msats == conv_float.msats  # equal for small integers
+        assert conv_int.msats == Decimal("4408000")
+
+
+# ---------------------------------------------------------------------------
+# Accumulated rounding drift simulation
+# ---------------------------------------------------------------------------
+
+
+class TestAccumulatedRoundingDrift:
+    """
+    Simulate the accumulation of sub-msat residuals to verify the fix.
+
+    Before the fix: recording fractional msats in ledger entries while Lightning
+    payments use integer msats causes the running total to drift.
+
+    After the fix: using msats_rounded in ledger entries eliminates the drift.
+    """
+
+    # Realistic HIVE amounts from live data (chosen to produce fractional msats)
+    HIVE_AMOUNTS = [
+        "53.999",
+        "1.087",  # produces ~1,087,340.9 msats at typical rate
+        "12.296",
+        "0.985",
+        "6.976",
+        "6.794",
+    ]
+
+    def _simulate_transactions(self, use_rounded: bool) -> Decimal:
+        """
+        For each HIVE amount, compute the cust_conv ledger credit and the
+        corresponding Lightning send (which uses integer msats = floor of fractional).
+
+        Returns the accumulated residual: sum(credit - debit).
+        """
+        quote = make_quote(sats_per_hive="81.565")
+        total_residual = Decimal("0")
+
+        for amount_str in self.HIVE_AMOUNTS:
+            conv = CryptoConversion(
+                value=Decimal(amount_str), conv_from=Currency.HIVE, quote=quote
+            ).conversion
+
+            # cust_conv ledger credit: fractional or rounded
+            credit = conv.msats_rounded if use_rounded else conv.msats
+
+            # Lightning payment always truncates to integer msats (floor)
+            lightning_send = conv.msats.to_integral_value(rounding="ROUND_FLOOR")
+
+            # Running total per transaction: credit - debit
+            total_residual += credit - lightning_send
+
+        return total_residual
+
+    def test_without_rounding_residual_accumulates(self):
+        """Without rounding, fractional msats accumulate across transactions."""
+        residual = self._simulate_transactions(use_rounded=False)
+        # The residual should be the sum of fractional parts (all positive)
+        assert residual > 0, "Expected positive drift from unrounded ledger entries"
+        # It should be clearly sub-msat in total (each fraction is < 1 msat)
+        assert residual < len(self.HIVE_AMOUNTS), "Residual bounded by transaction count"
+
+    def test_with_msats_rounded_residual_bounded_to_half_msat_per_tx(self):
+        """
+        With msats_rounded (ROUND_HALF_UP), the residual per transaction is
+        at most ±0.5 msats.  Over N transactions the maximum accumulated drift
+        is N/2 msats — dramatically smaller than the unrounded case.
+        """
+        quote = make_quote(sats_per_hive="81.565")
+        n = len(self.HIVE_AMOUNTS)
+        max_expected = Decimal(n) * Decimal("0.5")
+
+        residual = self._simulate_transactions(use_rounded=True)
+        assert abs(residual) <= max_expected, (
+            f"Rounded residual {residual} exceeds expected max {max_expected}"
+        )
+
+    def test_large_scale_unrounded_drift_grows_linearly(self):
+        """Demonstrate that unrounded drift grows with transaction count."""
+        quote = make_quote(sats_per_hive="81.565")
+        amounts = [Decimal("53.999")] * 100
+        drift = Decimal("0")
+        for amt in amounts:
+            conv = CryptoConversion(value=amt, conv_from=Currency.HIVE, quote=quote).conversion
+            drift += conv.msats - conv.msats.to_integral_value(rounding="ROUND_FLOOR")
+
+        # Each transaction contributes the fractional part of conv.msats.
+        # The exact amount depends on the rate; over 100 transactions the drift
+        # should be at least 10 msats (clearly non-trivial).
+        assert drift > Decimal("10"), "Expected drift > 10 msats for 100 identical transactions"
+
+    def test_large_scale_rounded_drift_stays_bounded(self):
+        """With msats_rounded, drift over 100 identical transactions stays near zero."""
+        quote = make_quote(sats_per_hive="81.565")
+        amounts = [Decimal("53.999")] * 100
+        drift = Decimal("0")
+        for amt in amounts:
+            conv = CryptoConversion(value=amt, conv_from=Currency.HIVE, quote=quote).conversion
+            # Rounded credit vs floor debit
+            credit = conv.msats_rounded
+            debit = conv.msats.to_integral_value(rounding="ROUND_FLOOR")
+            drift += credit - debit
+
+        # With ROUND_HALF_UP: 4544449.839963 → rounded up → credit=4544450, debit=4544449
+        # Each tx contributes +1 msat; total over 100 = +100 msats.
+        # This is still vastly better than the unrounded ~+84 msats per transaction × 100.
+        assert abs(drift) <= 100, f"Per-transaction residual with rounding: {drift / 100} msats"

--- a/uv.lock
+++ b/uv.lock
@@ -1909,14 +1909,14 @@ wheels = [
 
 [[package]]
 name = "matplotlib-inline"
-version = "0.2.1"
+version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
 ]
 
 [[package]]
@@ -2692,16 +2692,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.14.0"
+version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
 ]
 
 [[package]]
@@ -3541,41 +3541,41 @@ wheels = [
 
 [[package]]
 name = "types-aiofiles"
-version = "25.1.0.20260409"
+version = "25.1.0.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/66/9e62a2692792bc96c0f423f478149f4a7b84720704c546c8960b0a047c89/types_aiofiles-25.1.0.20260409.tar.gz", hash = "sha256:49e67d72bdcf9fe406f5815758a78dc34a1249bb5aa2adba78a80aec0a775435", size = 14812, upload-time = "2026-04-09T04:22:35.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/d9/60e8b26ad7e57eb3b58f3370b35f0d740dd0909079417e784f4e6c0f92f6/types_aiofiles-25.1.0.20260508.tar.gz", hash = "sha256:d26b07bb28f36c154c77d33982e506ee462044932d42c4eea6e78f69d1de5b84", size = 14851, upload-time = "2026-05-08T04:49:48.446Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/d0/28236f869ba4dfb223ecdbc267eb2bdb634b81a561dd992230a4f9ec48fa/types_aiofiles-25.1.0.20260409-py3-none-any.whl", hash = "sha256:923fedb532c772cc0f62e0ce4282725afa82ca5b41cabd9857f06b55e5eee8de", size = 14372, upload-time = "2026-04-09T04:22:34.328Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/88/31d8fb1a3d0a96e1e41cfc58c67f48634e840e2598336887fa5be1dd9c82/types_aiofiles-25.1.0.20260508-py3-none-any.whl", hash = "sha256:c35d2be25a7e4b881da7f62ff3823db3770b2f704f31ac69681c227569e808cc", size = 14365, upload-time = "2026-05-08T04:49:47.302Z" },
 ]
 
 [[package]]
 name = "types-cffi"
-version = "2.0.0.20260506"
+version = "2.0.0.20260508"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "types-setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/d0/b54c7338ae45580c56daed5f7d468e359a415b73637affed164f33d83a76/types_cffi-2.0.0.20260506.tar.gz", hash = "sha256:8cf63d7006bf0fec825cc5a70fa637ed783b25ef0d0980d09f27606600123f75", size = 17718, upload-time = "2026-05-06T05:17:56.098Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/17/dd80304dade64eefae44f273e829734fc01243bf94555e787386c09146a9/types_cffi-2.0.0.20260508.tar.gz", hash = "sha256:746b081b4bf84f9d8855c517a67c2dff717f3c18657fcff8e9c251fb5778f311", size = 17750, upload-time = "2026-05-08T04:51:48.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/cf/b562968181a5374c9bddaf5f543ddd857d1072c578e77f63744d8a8d3a17/types_cffi-2.0.0.20260506-py3-none-any.whl", hash = "sha256:43472f8e31f8dc7abbf0c4119828f79c3f4a048b5edcebd19538ee6cf3ca69ed", size = 20195, upload-time = "2026-05-06T05:17:54.925Z" },
+    { url = "https://files.pythonhosted.org/packages/18/02/95d98d4473197da55bb5b9c67f7ff1e49c0a12ca870e29004129f635be18/types_cffi-2.0.0.20260508-py3-none-any.whl", hash = "sha256:d094065daf4edcfbdd3e11c37d2fa9511eaf7c509da7a9d9573c276398a8e745", size = 20174, upload-time = "2026-05-08T04:51:47.548Z" },
 ]
 
 [[package]]
 name = "types-colorama"
-version = "0.4.15.20260408"
+version = "0.4.15.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/83/c0/1c02ed9edf3462a392f4ea4bda80fa10c538c63d1d7be255dc7dcb545007/types_colorama-0.4.15.20260408.tar.gz", hash = "sha256:9a816657927489463edec1b7b47933b73fe737d37a3616bf596b7de843441032", size = 10623, upload-time = "2026-04-08T04:28:31.763Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/d5/4870d88c6c87adf786ef33d674cbf82b3a2d5fcbe6deec29282cff80e8b3/types_colorama-0.4.15.20260508.tar.gz", hash = "sha256:3a8916039e57452bd21f57e674e1f221ca9e4f319893c5e3bbd37b845c27d8e6", size = 10638, upload-time = "2026-05-08T04:47:14.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/65/d03948be8ae9362ad26f36443eab051fe5524295fe008126cd65792f9833/types_colorama-0.4.15.20260408-py3-none-any.whl", hash = "sha256:7327a51c760d94f7df2e8c72c275a4468c03c3abb606d23995cb37e3d24d9132", size = 10763, upload-time = "2026-04-08T04:28:30.688Z" },
+    { url = "https://files.pythonhosted.org/packages/56/33/a3449e3e93c43861b92d0a93ed4ea5505756463e507625812cfb29c91c7a/types_colorama-0.4.15.20260508-py3-none-any.whl", hash = "sha256:b0c39908a3e5171ef1f8bf3d59fae082e9eaff3a19ca49b6d640b83f78cff61c", size = 10755, upload-time = "2026-05-08T04:47:13.761Z" },
 ]
 
 [[package]]
 name = "types-protobuf"
-version = "7.34.1.20260503"
+version = "7.34.1.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a0/31/87969cb3e62287bde7598b78b3c098d2873d54f5fb5a7cfbcaa73b8c965e/types_protobuf-7.34.1.20260503.tar.gz", hash = "sha256:effbc819aa17e02448dde99f089c6794662d66f4b2797e922f185ffe0b24e766", size = 68830, upload-time = "2026-05-03T05:19:50.739Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/1b/4ae76c732caa3ff5786ac9039d592d526ff2db898da93176c40b63e0b110/types_protobuf-7.34.1.20260508.tar.gz", hash = "sha256:1c93e8c294281b76a5255fc21c747db0004694463ac6ea9866ee06da969fa555", size = 68871, upload-time = "2026-05-08T04:46:17.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/67/a33fb18090a927794a5ee4b1a30730b528ace0dad6b18932540d21258184/types_protobuf-7.34.1.20260503-py3-none-any.whl", hash = "sha256:75fd66121d56785c91828b8bf7b511f39ba847f11e682573e41847f01e9cd1de", size = 86019, upload-time = "2026-05-03T05:19:49.486Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/61/c94036a4690e18059e55451ba5ce6294ea790651a0f5a429ad961e6b9675/types_protobuf-7.34.1.20260508-py3-none-any.whl", hash = "sha256:a5d647381f8651bd505304ed1148b8a7b342781796e0f80e0284c774c2262a09", size = 85984, upload-time = "2026-05-08T04:46:16.422Z" },
 ]
 
 [[package]]
@@ -3593,11 +3593,11 @@ wheels = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20260408"
+version = "6.0.12.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/6b/f9d82598121b2f0532238381aec27734c24a0ff548ac352b358c2857a176/types_pyyaml-6.0.12.20260508.tar.gz", hash = "sha256:5ae42149c3ebf7aaaf6c65ee49af590c80f0ba52e9e3f75a75c5564b33556fa6", size = 17776, upload-time = "2026-05-08T04:48:28.682Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/96690460fe7f4e4b4ab0ecd79a8609aec2ae63927ad97625f3c747ca6a1d/types_pyyaml-6.0.12.20260508-py3-none-any.whl", hash = "sha256:edc094ed3a918b0c6232f71a5b67fdf38e76e17517b7d87bfbb9fc27d442fb51", size = 20309, upload-time = "2026-05-08T04:48:27.822Z" },
 ]
 
 [[package]]
@@ -3615,41 +3615,41 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.33.0.20260503"
+version = "2.33.0.20260508"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/b8/57e94268c0d82ac3eaa2fc35aa8ca7bbc2542f726b67dcf90b0b00a3b14d/types_requests-2.33.0.20260503.tar.gz", hash = "sha256:9721b2d9dbee7131f2fb39f20f0ebb1999c18cef4b512c9a7932f3722de7c5f4", size = 23931, upload-time = "2026-05-03T05:20:08.882Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/6b/eb226bdd61a982c9a03e02c657fb4ab001733506e6423906ac142331f2e3/types_requests-2.33.0.20260508.tar.gz", hash = "sha256:81b2ae5f0d20967714a6aa5ef9284c05570d7cb06b7de8f2a77b918b63ddd411", size = 23991, upload-time = "2026-05-08T04:50:56.818Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/82/959113a6351f3ca046cd0a8cd2cee071d7ea47473560557a01eeae9a6fe2/types_requests-2.33.0.20260503-py3-none-any.whl", hash = "sha256:02aaa7e3577a13471715bb1bddb693cc985ea514f754b503bf033e6a09a3e528", size = 20736, upload-time = "2026-05-03T05:20:07.858Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/96/080db0afdf2c5cc5fe512b41354e8d114fe8f65e9510c56ff8dfd40216ce/types_requests-2.33.0.20260508-py3-none-any.whl", hash = "sha256:fa01459cca184229713df03709db46a905325906d27e042cd4fd7ea3d15d3400", size = 20722, upload-time = "2026-05-08T04:50:55.548Z" },
 ]
 
 [[package]]
 name = "types-setuptools"
-version = "82.0.0.20260408"
+version = "82.0.0.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/12/3464b410c50420dd4674fa5fe9d3880711c1dbe1a06f5fe4960ee9067b9e/types_setuptools-82.0.0.20260408.tar.gz", hash = "sha256:036c68caf7e672a699f5ebbf914708d40644c14e05298bc49f7272be91cf43d3", size = 44861, upload-time = "2026-04-08T04:29:33.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/53/8c7ca2263165f13b493f5258a317acb09cab02742e816c38cd5fe6f09e5a/types_setuptools-82.0.0.20260508.tar.gz", hash = "sha256:e76ade6f42ba9b4211636b84b65a8e55948a67ffe81f9a44e66b8af93d57e77e", size = 44919, upload-time = "2026-05-08T04:47:48.32Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/e1/46a4fc3ef03aabf5d18bac9df5cf37c6b02c3bddf3e05c3533f4b4588331/types_setuptools-82.0.0.20260408-py3-none-any.whl", hash = "sha256:ece0a215cdfa6463a65fd6f68bd940f39e455729300ddfe61cab1147ed1d2462", size = 68428, upload-time = "2026-04-08T04:29:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/67/f49414a00fc61a4bc64bd0ff879bb230818b68e62c5cf91fc7c098912aac/types_setuptools-82.0.0.20260508-py3-none-any.whl", hash = "sha256:ba1d863bbd11526d7232bca8d5a4aebe1d38fa1677a550f47a2692b7d5776900", size = 68395, upload-time = "2026-05-08T04:47:47.391Z" },
 ]
 
 [[package]]
 name = "types-tabulate"
-version = "0.10.0.20260408"
+version = "0.10.0.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/59/b563bfb6e216b8573052c09cb4abcbdca836487db4cfad9b7d492c327c0b/types_tabulate-0.10.0.20260408.tar.gz", hash = "sha256:903d62fdf7e5a0ff659fd5d629df716232f7658c6d30e98f0374488d06ffacf4", size = 8367, upload-time = "2026-04-08T04:30:00.482Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/af/c100d86897d3fdb010d8f813569fa80355b5cb553f51080e37d4f3c451bb/types_tabulate-0.10.0.20260508.tar.gz", hash = "sha256:8e51f159e8b24976849706ae2ed1dc9adba8ebbd080b17e494ebb66a8cc92c74", size = 8395, upload-time = "2026-05-08T04:47:58.921Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/d1/34e27f543dd944f51fc6b0013a1a41113079cede9cc3be0a5f426f2f8d9d/types_tabulate-0.10.0.20260408-py3-none-any.whl", hash = "sha256:2b19d193603d38c34645de53c0c1087e2364487d518d4a2f44268db2366723cc", size = 8139, upload-time = "2026-04-08T04:29:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/36/443b700f54a585cf8ed4e76d8ad08b12df6914f8782a2788ecd0d8491519/types_tabulate-0.10.0.20260508-py3-none-any.whl", hash = "sha256:b1e1a2d0456fbd655a71690b09a7aaeffdf2978d32049184ea436492aa51d20a", size = 8137, upload-time = "2026-05-08T04:47:57.872Z" },
 ]
 
 [[package]]
 name = "types-toml"
-version = "0.10.8.20260408"
+version = "0.10.8.20260508"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/9b/887564a51a84c96ba08b715570e546f0ea793df6372b736bfbc596ca5536/types_toml-0.10.8.20260408.tar.gz", hash = "sha256:6b30b031235565a12febb1388900b129f1adeabfcfa594da46d0372b2ac107ad", size = 9341, upload-time = "2026-04-08T04:27:54.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/3d/df34d25e9d1fbbda6af6033bb13cf228a11d838d11bea93a05840d43d98d/types_toml-0.10.8.20260508.tar.gz", hash = "sha256:93aaa72365bd9bc8c2ce1ca3502b0470d8d428376bada020e1a4956b8b82fdda", size = 9380, upload-time = "2026-05-08T04:46:58.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/f1/942d95ba026779bc6e3064f8b094216588dc3276cc328cf8e03a0541918d/types_toml-0.10.8.20260408-py3-none-any.whl", hash = "sha256:e958d4c660385e548705a298f17dc162baf44c8b6d6aff79aeefe75f4f77ac87", size = 9677, upload-time = "2026-04-08T04:27:53.526Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e1/cb6b12945b2d0ae8f93bfab320be81a8f5bb8b6e1384744ca05c9a6909c0/types_toml-0.10.8.20260508-py3-none-any.whl", hash = "sha256:144d615419051493ab1e5e71b6477f7c56fadc78f0856407775e75c8e2916140", size = 9662, upload-time = "2026-05-08T04:46:57.709Z" },
 ]
 
 [[package]]
@@ -3693,11 +3693,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]
@@ -3758,7 +3758,7 @@ wheels = [
 
 [[package]]
 name = "v4vapp-backend-v2"
-version = "2.8.3"
+version = "2.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
This pull request addresses accumulated rounding drift in msats (millisatoshis) ledger entries by ensuring all msats values used in accounting and conversion flows are rounded to the nearest integer using ROUND_HALF_UP. This eliminates the buildup of sub-msat residuals in VSC Liability accounts and improves both correctness and performance of balance queries. The changes also introduce a new property to the crypto conversion helper, update relevant models and conversion flows, and add comprehensive test coverage.

**Rounding and Ledger Consistency Improvements:**

* Added a new `msats_rounded` property to the `CryptoConv` class in `crypto_conversion.py`, rounding msats to the nearest integer using ROUND_HALF_UP, to be used in all ledger entries that correspond to Lightning Network payments. This prevents the accumulation of fractional msats drift over many transactions.
* Updated all conversion flows (`hive_to_keepsats.py` and `keepsats_to_hive.py`) to use the new `msats_rounded` property for all debit and credit amounts involving msats in ledger entries, ensuring consistency and eliminating sub-msat drift. [[1]](diffhunk://#diff-9038156f37924b152c73cb4e0f2087e47257bc98a45acc03897b1fc07a4066e9L139-R139) [[2]](diffhunk://#diff-9038156f37924b152c73cb4e0f2087e47257bc98a45acc03897b1fc07a4066e9L203-R203) [[3]](diffhunk://#diff-3f3ad9e0673cbd78f614b07352f899c891966e2a17a427989b8cbb6c0b01b27cL175-R175) [[4]](diffhunk://#diff-3f3ad9e0673cbd78f614b07352f899c891966e2a17a427989b8cbb6c0b01b27cL285-R291) [[5]](diffhunk://#diff-3f3ad9e0673cbd78f614b07352f899c891966e2a17a427989b8cbb6c0b01b27cL344-R350)

**Model and Data Handling Updates:**

* Modified `update_conv` methods in `invoice_models.py` and `payment_models.py` to use `int(amount_msat)` instead of `float(amount_msat)`, ensuring msats values are always treated as integers in conversions and fee calculations. [[1]](diffhunk://#diff-d57f17e0afa0155eca0176ea7e1888669fd1dc5cc83e019260ad089c2fae4bbbL308-R308) [[2]](diffhunk://#diff-ced681adb8905d5e79d729f8fde9b18ae0bb9bb2e17efa8147044cbfcc921726L180-R185)
* Minor code cleanup in `route_str` method to simplify list comprehension formatting.

**Accounting and Performance Enhancements:**

* Improved the `all_account_balances_summary` function to merge contra and non-contra account variants into a single entry per (account_type, name, sub), summing their values for accurate net balances and improved performance.
* Optimized the `keepsats_balance` function to use a faster, summary-based aggregation path when only a balance is needed (not full transaction history), significantly improving performance for high-volume accounts. [[1]](diffhunk://#diff-112fc60ae61ec19086e54fc3a2b8266965bdd23d40997322bc5b4072c3c286f8L1657-R1685) [[2]](diffhunk://#diff-112fc60ae61ec19086e54fc3a2b8266965bdd23d40997322bc5b4072c3c286f8R1696-L1670)

**Documentation and Test Coverage:**

* Added detailed documentation in `docs/ledger_audit_2026_05.md` explaining the root cause, changes, test coverage, and rationale for the rounding fix, as well as the handling of historical data.
* Introduced a new test file `tests/helpers/test_msats_rounding.py` with comprehensive unit and simulation tests verifying the new rounding logic and its effect on accumulated drift.

**Imports and Code Organization:**

* Updated imports in `account_balances.py` to include `AccountType` for clarity and maintainability.