### PR TITLE
Add optional index floors for LND sequences

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -133,7 +133,7 @@
             "program": "src/lnd_monitor_v2.py",
             "args": [
                 "--config",
-                "legiondev.config.yaml"
+                "devlegion.config.yaml"
             ],
             "console": "integratedTerminal",
             "env": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "v4vapp-backend-v2"
-version = "2.10.2"
+version = "2.10.3"
 description = "Back End for the V4V.app bridge from Hive to Lightning"
 authors = [{name = "Brian of London (home imac)", email = "brian@v4v.app"}]
 license = {text = "MIT"}

--- a/src/lnd_monitor_v2.py
+++ b/src/lnd_monitor_v2.py
@@ -1589,9 +1589,9 @@ async def expired_invoices_maintenance_loop(
     interval_seconds: int = EXPIRED_INVOICE_PRUNE_INTERVAL_SECONDS,
 ) -> None:
     """
-    Periodically find expired, unsettled invoices past the retention window.
+    Periodically delete expired, unsettled invoices past the retention window.
 
-    Find-only for now (no deletes). Runs once at start, then every ``interval_seconds``.
+    Deletes expired invoices. Runs once at start, then every ``interval_seconds``.
     """
     logger.info(
         f"{lnd_client.icon} expired_invoices_maintenance_loop started "

--- a/src/lnd_monitor_v2.py
+++ b/src/lnd_monitor_v2.py
@@ -1582,6 +1582,7 @@ async def _background_sync(lnd_client: LNDClient) -> None:
 
 
 EXPIRED_INVOICE_PRUNE_INTERVAL_SECONDS = 3600  # 1 hour
+TIMEDELTA_RETAIN_AFTER_EXPIRY = timedelta(days=1)  # Retain expired invoices for 1 day
 
 
 async def expired_invoices_maintenance_loop(
@@ -1600,7 +1601,7 @@ async def expired_invoices_maintenance_loop(
     while not shutdown_event.is_set():
         try:
             count = await delete_expired_unsettled_invoices(
-                collection=Invoice.collection(), retain_after_expiry=timedelta(seconds=0)
+                collection=Invoice.collection(), retain_after_expiry=TIMEDELTA_RETAIN_AFTER_EXPIRY
             )
             if count > 0:
                 logger.info(

--- a/src/lnd_monitor_v2.py
+++ b/src/lnd_monitor_v2.py
@@ -26,6 +26,7 @@ from v4vapp_backend_v2.config.setup import (
     logger,
 )
 from v4vapp_backend_v2.database.db_pymongo import DATABASE_ICON, DBConn
+from v4vapp_backend_v2.database.db_tools import delete_expired_unsettled_invoices
 from v4vapp_backend_v2.events.async_event import async_publish, async_subscribe
 from v4vapp_backend_v2.events.event_models import Events
 from v4vapp_backend_v2.grpc_models.lnd_events_group import (
@@ -56,6 +57,71 @@ NOTIFICATION_QUITE_MODE = (
 )
 
 app = typer.Typer()
+
+
+@dataclass(frozen=True)
+class LndIndexFloors:
+    """Exclusive floors for LND sequence indexes (process only values strictly greater)."""
+
+    add_index: int = 0
+    settle_index: int = 0
+    payment_index: int = 0
+
+    @property
+    def has_any(self) -> bool:
+        return self.add_index > 0 or self.settle_index > 0 or self.payment_index > 0
+
+
+def get_lnd_index_floors(connection_name: str | None = None) -> LndIndexFloors:
+    """
+    Load optional index floors from the LND connection config.
+
+    Missing config fields behave as 0 (no floor). When ``start_settle_index`` is
+    omitted but ``start_add_index`` is set, the add-index floor is also used for
+    settle so SubscribeInvoices does not re-emit pre-cutover settles.
+    """
+    lnd_config = InternalConfig().config.lnd_config
+    conn = lnd_config.connection_config(connection_name)
+    if conn is None:
+        return LndIndexFloors()
+
+    add_floor = int(conn.start_add_index or 0)
+    if conn.start_settle_index is not None:
+        settle_floor = int(conn.start_settle_index)
+    else:
+        settle_floor = add_floor
+    payment_floor = int(conn.start_payment_index or 0)
+    return LndIndexFloors(
+        add_index=add_floor,
+        settle_index=settle_floor,
+        payment_index=payment_floor,
+    )
+
+
+def apply_invoice_index_floors(
+    add_index: int | None,
+    settle_index: int | None,
+    floors: LndIndexFloors,
+) -> tuple[int, int]:
+    """Raise subscription cursors so they are never below configured floors."""
+    add = int(add_index or 0)
+    settle = int(settle_index or 0)
+    return max(add, floors.add_index), max(settle, floors.settle_index)
+
+
+def should_ignore_invoice_index(add_index: int | None, floors: LndIndexFloors) -> bool:
+    """True when this invoice's add_index is at or below the configured floor."""
+    if floors.add_index <= 0:
+        return False
+    return int(add_index or 0) <= floors.add_index
+
+
+def should_ignore_payment_index(payment_index: int | None, floors: LndIndexFloors) -> bool:
+    """True when this payment's payment_index is at or below the configured floor."""
+    if floors.payment_index <= 0:
+        return False
+    return int(payment_index or 0) <= floors.payment_index
+
 
 # Define a global flag to track shutdown and startup completion
 startup_complete_event = asyncio.Event()
@@ -195,9 +261,7 @@ async def track_events(
                     forward_event = TrackedForwardEvent.model_validate(ans_dict)
                     forward_event.node_name = lnd_client.connection.name
                     asyncio.create_task(
-                        db_store_htlc_event(
-                            forward_event=forward_event, lnd_client=lnd_client
-                        )
+                        db_store_htlc_event(forward_event=forward_event, lnd_client=lnd_client)
                     )
                 except Exception as e:
                     logger.warning(
@@ -331,6 +395,17 @@ async def db_store_invoice(
         None
     """
     try:
+        floors = get_lnd_index_floors(lnd_client.connection.name)
+        # add_index is on the protobuf event; filter before building the full model
+        raw_add_index = getattr(htlc_event, "add_index", 0)
+        if should_ignore_invoice_index(raw_add_index, floors):
+            logger.debug(
+                f"{lnd_client.icon} Skipping invoice add_index={raw_add_index} "
+                f"(<= floor {floors.add_index})",
+                extra={"notification": False},
+            )
+            return
+
         invoice_pyd = Invoice(htlc_event)
         invoice_pyd.node_name = lnd_client.connection.name
         await invoice_pyd.update_conv()
@@ -361,6 +436,16 @@ async def db_store_payment(
         None
     """
     try:
+        floors = get_lnd_index_floors(lnd_client.connection.name)
+        raw_payment_index = getattr(htlc_event, "payment_index", 0)
+        if should_ignore_payment_index(raw_payment_index, floors):
+            logger.debug(
+                f"{lnd_client.icon} Skipping payment payment_index={raw_payment_index} "
+                f"(<= floor {floors.payment_index})",
+                extra={"notification": False},
+            )
+            return
+
         payment_pyd = Payment(htlc_event)
         payment_pyd.node_name = lnd_client.connection.name
         # Attach invoice description (decoded from payment_request) if available
@@ -567,12 +652,13 @@ async def invoices_loop(
     """
     logger.info(f"{lnd_client.icon} invoices_loop task started")
 
+    floors = get_lnd_index_floors(lnd_client.connection.name)
     try:
         recent_invoice = await asyncio.wait_for(get_most_recent_invoice(), timeout=30)
     except asyncio.TimeoutError:
         logger.warning(
             "Timed out querying DB for most recent invoice in invoices_loop (30s). "
-            "Starting subscription from index 0.",
+            "Starting subscription from index floors or 0.",
             extra={"notification": True},
         )
         recent_invoice = None
@@ -588,6 +674,16 @@ async def invoices_loop(
             return
         except asyncio.TimeoutError:
             pass
+
+    add_index, settle_index = apply_invoice_index_floors(add_index, settle_index, floors)
+    if floors.has_any:
+        logger.info(
+            f"{lnd_client.icon} Invoice subscription floors: "
+            f"add_index>={add_index} settle_index>={settle_index} "
+            f"(config start_add_index={floors.add_index}, "
+            f"start_settle_index={floors.settle_index})",
+            extra={"notification": False},
+        )
 
     request_sub = lnrpc.InvoiceSubscription(
         add_index=int(add_index) if add_index is not None else 0,
@@ -632,6 +728,13 @@ async def invoices_loop(
 
 async def payments_loop(lnd_client: LNDClient, lnd_events_group: LndEventsGroup) -> None:
     logger.info(f"{lnd_client.icon} payments_loop task started")
+    floors = get_lnd_index_floors(lnd_client.connection.name)
+    if floors.payment_index > 0:
+        logger.info(
+            f"{lnd_client.icon} Payment store floor: payment_index>{floors.payment_index} "
+            f"(TrackPayments is live-only; pre-floor payments are dropped at store/backfill)",
+            extra={"notification": False},
+        )
     request = routerrpc.TrackPaymentRequest(no_inflight_updates=False)
     while True:
         try:
@@ -949,6 +1052,7 @@ async def read_all_invoices(lnd_client: LNDClient) -> None:
         index_offset = 0
         num_max_invoices = 1000
         total_invoices = 0
+        floors = get_lnd_index_floors(lnd_client.connection.name)
         logger.info(f"{lnd_client.icon} Reading all invoices...")
         while True:
             if shutdown_event.is_set():
@@ -967,6 +1071,8 @@ async def read_all_invoices(lnd_client: LNDClient) -> None:
             index_offset = list_invoices.first_index_offset
             bulk_updates = []
             for invoice in list_invoices.invoices:
+                if should_ignore_invoice_index(invoice.add_index, floors):
+                    continue
                 read_invoice = await Invoice.collection().find_one(
                     filter={"r_hash": invoice.r_hash},
                 )
@@ -1036,6 +1142,7 @@ async def read_all_payments(lnd_client: LNDClient) -> None:
         index_offset = 0
         num_max_payments = 1000
         total_payments = 0
+        floors = get_lnd_index_floors(lnd_client.connection.name)
         logger.info(f"{lnd_client.icon} Reading all payments...")
         while True:
             if shutdown_event.is_set():
@@ -1054,6 +1161,8 @@ async def read_all_payments(lnd_client: LNDClient) -> None:
             index_offset = payments_raw.first_index_offset
             bulk_updates = []
             for payment in list_payments.payments:
+                if should_ignore_payment_index(payment.payment_index, floors):
+                    continue
                 query = {"payment_hash": payment.payment_hash}
                 read_payment = await Payment.collection().find_one(
                     filter=query,
@@ -1341,6 +1450,10 @@ async def main_async_start(connection_name: str) -> None:
                     _background_sync(lnd_client),
                     name="synchronize_db",
                 ),
+                asyncio.create_task(
+                    expired_invoices_maintenance_loop(lnd_client=lnd_client),
+                    name="expired_invoices_maintenance",
+                ),
                 asyncio.create_task(status_api.start(), name="status_api"),
             ]
             critical_tasks = [
@@ -1466,6 +1579,57 @@ async def _background_sync(lnd_client: LNDClient) -> None:
             f"Background sync failed: {e}",
             extra={"notification": False},
         )
+
+
+EXPIRED_INVOICE_PRUNE_INTERVAL_SECONDS = 3600  # 1 hour
+
+
+async def expired_invoices_maintenance_loop(
+    lnd_client: LNDClient,
+    interval_seconds: int = EXPIRED_INVOICE_PRUNE_INTERVAL_SECONDS,
+) -> None:
+    """
+    Periodically find expired, unsettled invoices past the retention window.
+
+    Find-only for now (no deletes). Runs once at start, then every ``interval_seconds``.
+    """
+    logger.info(
+        f"{lnd_client.icon} expired_invoices_maintenance_loop started "
+        f"(interval={interval_seconds}s)"
+    )
+    while not shutdown_event.is_set():
+        try:
+            count = await delete_expired_unsettled_invoices(
+                collection=Invoice.collection(), retain_after_expiry=timedelta(seconds=0)
+            )
+            if count > 0:
+                logger.info(
+                    f"{lnd_client.icon}{DATABASE_ICON} Expired unsettled invoices "
+                    f"eligible for prune: {count}",
+                    extra={
+                        "notification": False,
+                        "expired_unsettled_invoice_count": count,
+                    },
+                )
+            else:
+                logger.debug(
+                    f"{lnd_client.icon}{DATABASE_ICON} No expired unsettled invoices found for prune",
+                    extra={"notification": False},
+                )
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            logger.info(f"{lnd_client.icon} expired_invoices_maintenance_loop cancelled")
+            return
+        except Exception as e:
+            logger.warning(
+                f"{lnd_client.icon} expired invoice maintenance find failed: {e}",
+                extra={"notification": False},
+            )
+
+        try:
+            await asyncio.wait_for(shutdown_event.wait(), timeout=interval_seconds)
+            return
+        except asyncio.TimeoutError:
+            pass
 
 
 async def pause_for_database_sync() -> bool:

--- a/src/v4vapp_backend_v2/config/setup.py
+++ b/src/v4vapp_backend_v2/config/setup.py
@@ -177,6 +177,29 @@ class LndConnectionConfig(BaseConfig):
     macaroon_filename: str = ""
     cert_filename: str = ""
     use_proxy: str = ""
+    # Optional exclusive floors for this node's LND sequences (ignore index <= floor).
+    # When omitted, existing behaviour is unchanged (resume from Mongo / start at 0).
+    start_add_index: int | None = Field(
+        default=None,
+        description=(
+            "Ignore invoices with add_index <= this value. Also used as the minimum "
+            "SubscribeInvoices add_index cursor (max of this and the DB watermark)."
+        ),
+    )
+    start_settle_index: int | None = Field(
+        default=None,
+        description=(
+            "Optional settle_index floor for SubscribeInvoices. If omitted but "
+            "start_add_index is set, start_add_index is used as the settle floor too."
+        ),
+    )
+    start_payment_index: int | None = Field(
+        default=None,
+        description=(
+            "Ignore payments with payment_index <= this value (TrackPayments has no "
+            "resume cursor; filtering is applied when storing / backfilling)."
+        ),
+    )
 
 
 class LndConfig(BaseConfig):
@@ -185,6 +208,13 @@ class LndConfig(BaseConfig):
     lightning_fee_limit_ppm: int = 5000
     lightning_fee_estimate_ppm: int = 1000
     lightning_fee_base_msats: int = 50000
+
+    def connection_config(self, name: str | None = None) -> LndConnectionConfig | None:
+        """Return the named connection config, or the default connection if name is None."""
+        conn_name = name or self.default
+        if not conn_name:
+            return None
+        return self.connections.get(conn_name)
 
 
 class TailscaleConfig(BaseConfig):

--- a/src/v4vapp_backend_v2/database/db_tools.py
+++ b/src/v4vapp_backend_v2/database/db_tools.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from typing import Any, Dict, Mapping, Optional
 
@@ -220,3 +220,95 @@ async def find_nearest_by_timestamp_server_side(
 
     candidate = docs[0]
     return convert_decimal128_to_decimal(candidate)
+
+
+def expired_unsettled_invoice_query(
+    as_of: datetime | None = None,
+    retain_after_expiry: timedelta = timedelta(days=1),
+) -> Dict[str, Any]:
+    """
+    Build the MongoDB filter for expired, unpaid invoices past the retention window.
+
+    Criteria (as used in production pruning):
+      - settle_index == 0
+      - settled is false
+      - expiry_date is strictly before (as_of - retain_after_expiry)
+
+    With the default retain_after_expiry of 1 day, invoices remain eligible only after
+    they have been expired for more than 24 hours (so ~1 day of unpaid history is kept).
+
+    Args:
+        as_of: Reference time (UTC). Defaults to now (UTC).
+        retain_after_expiry: How long after expiry_date to keep the document.
+
+    Returns:
+        A dict suitable for collection.find(filter).
+    """
+    if as_of is None:
+        as_of = datetime.now(tz=timezone.utc)
+    elif as_of.tzinfo is None:
+        as_of = as_of.replace(tzinfo=timezone.utc)
+
+    cutoff = as_of - retain_after_expiry
+    return {
+        "settle_index": 0,
+        "settled": False,
+        "expiry_date": {"$lt": cutoff},
+    }
+
+
+async def find_expired_unsettled_invoices(
+    collection: AsyncCollection,
+    as_of: datetime | None = None,
+    retain_after_expiry: timedelta = timedelta(days=1),
+    limit: int | None = None,
+) -> list[Dict[str, Any]]:
+    """
+    Find unpaid invoices whose expiry_date is older than the retention window.
+
+    Find-only helper for LND monitor maintenance (no deletes). Documents match
+    ``expired_unsettled_invoice_query``.
+
+    Args:
+        collection: MongoDB invoices collection (async).
+        as_of: Reference time (UTC). Defaults to now.
+        retain_after_expiry: Keep unpaid invoices this long after expiry (default 1 day).
+        limit: Optional max number of documents to return.
+
+    Returns:
+        List of matching documents (Decimal128 converted to Decimal).
+    """
+    query = expired_unsettled_invoice_query(
+        as_of=as_of, retain_after_expiry=retain_after_expiry
+    )
+    cursor = collection.find(query).sort("expiry_date", 1)
+    if limit is not None:
+        cursor = cursor.limit(limit)
+    docs = await cursor.to_list(length=limit)
+    return [convert_decimal128_to_decimal(doc) for doc in docs]
+
+
+async def delete_expired_unsettled_invoices(
+    collection: AsyncCollection,
+    as_of: datetime | None = None,
+    retain_after_expiry: timedelta = timedelta(days=1),
+) -> int:
+    """
+    Delete unpaid invoices whose expiry_date is older than the retention window.
+
+    Uses the same filter as ``find_expired_unsettled_invoices`` via
+    ``expired_unsettled_invoice_query`` and ``collection.delete_many``.
+
+    Args:
+        collection: MongoDB invoices collection (async).
+        as_of: Reference time (UTC). Defaults to now.
+        retain_after_expiry: Keep unpaid invoices this long after expiry (default 1 day).
+
+    Returns:
+        Number of documents deleted (``deleted_count`` from DeleteResult).
+    """
+    query = expired_unsettled_invoice_query(
+        as_of=as_of, retain_after_expiry=retain_after_expiry
+    )
+    result = await collection.delete_many(query)
+    return int(getattr(result, "deleted_count", 0))

--- a/tests/data/config/config.yaml
+++ b/tests/data/config/config.yaml
@@ -36,6 +36,10 @@ lnd_config:
       macaroon_filename: info-read.safe-macaroon
       cert_filename: tls-fake.safe-cert
       # use_proxy: http://proxy.example.com:8888
+      # Optional exclusive index floors (ignore index <= value):
+      # start_add_index: 10
+      # start_settle_index: 5
+      # start_payment_index: 3
 
     example2:
       address: example.com:10009
@@ -45,6 +49,8 @@ lnd_config:
       macaroon_filename: info-read.safe-macaroon
       cert_filename: tls-fake.safe-cert
       use_proxy: http://proxy.example.com:8888
+      start_add_index: 42
+      start_payment_index: 7
 
 ########### TEST CONFIG NO SECRETS #################
 

--- a/tests/database/test_db_tools.py
+++ b/tests/database/test_db_tools.py
@@ -5,6 +5,9 @@ import pytest
 from bson import Decimal128
 
 from v4vapp_backend_v2.database.db_tools import (
+    delete_expired_unsettled_invoices,
+    expired_unsettled_invoice_query,
+    find_expired_unsettled_invoices,
     find_nearest_by_timestamp,
     find_nearest_by_timestamp_server_side,
 )
@@ -305,3 +308,184 @@ async def test_find_nearest_only_before_or_after_server_side():
     res2 = await find_nearest_by_timestamp_server_side(coll2, target)
     assert res2 is not None
     assert res2["hive_usd"] == Decimal("2.0")
+
+
+# ---- Expired unsettled invoices (prune candidate finder) ----
+
+
+class _FakeDeleteResult:
+    def __init__(self, deleted_count: int):
+        self.deleted_count = deleted_count
+
+
+class FakeInvoiceCollection:
+    """Minimal async collection supporting find + sort + limit + delete_many for prune tests."""
+
+    def __init__(self, docs):
+        self.docs = list(docs)
+
+    def _matches(self, d, flt) -> bool:
+        for k, v in flt.items():
+            if isinstance(v, dict):
+                if "$lt" in v:
+                    field_val = d.get(k)
+                    if field_val is None or not (field_val < v["$lt"]):
+                        return False
+                elif "$lte" in v:
+                    field_val = d.get(k)
+                    if field_val is None or not (field_val <= v["$lte"]):
+                        return False
+                else:
+                    return False
+            else:
+                if d.get(k) != v:
+                    return False
+        return True
+
+    def find(self, flt):
+        matched = [d.copy() for d in self.docs if self._matches(d, flt)]
+        return FakeCursor(matched)
+
+    async def delete_many(self, flt):
+        keep = []
+        deleted = 0
+        for d in self.docs:
+            if self._matches(d, flt):
+                deleted += 1
+            else:
+                keep.append(d)
+        self.docs = keep
+        return _FakeDeleteResult(deleted)
+
+
+def test_expired_unsettled_invoice_query_cutoff():
+    as_of = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+    q = expired_unsettled_invoice_query(as_of=as_of, retain_after_expiry=timedelta(days=1))
+    assert q["settle_index"] == 0
+    assert q["settled"] is False
+    assert q["expiry_date"]["$lt"] == datetime(2026, 7, 27, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_find_expired_unsettled_invoices_filters_correctly():
+    as_of = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+    # Cutoff = as_of - 1 day = 2026-07-27 12:00 UTC
+    old_expired = {
+        "r_hash": "old",
+        "settle_index": 0,
+        "settled": False,
+        "expiry_date": datetime(2026, 7, 26, 0, 0, 0, tzinfo=timezone.utc),
+        "memo": "keep candidate",
+    }
+    recently_expired = {
+        "r_hash": "recent",
+        "settle_index": 0,
+        "settled": False,
+        "expiry_date": datetime(2026, 7, 27, 18, 0, 0, tzinfo=timezone.utc),  # within 24h
+        "memo": "too new",
+    }
+    settled = {
+        "r_hash": "paid",
+        "settle_index": 5,
+        "settled": True,
+        "expiry_date": datetime(2026, 7, 20, 0, 0, 0, tzinfo=timezone.utc),
+        "memo": "settled",
+    }
+    unsettled_but_settled_flag = {
+        "r_hash": "weird",
+        "settle_index": 0,
+        "settled": True,  # inconsistent but must not match
+        "expiry_date": datetime(2026, 7, 20, 0, 0, 0, tzinfo=timezone.utc),
+    }
+    not_expired_yet = {
+        "r_hash": "open",
+        "settle_index": 0,
+        "settled": False,
+        "expiry_date": datetime(2026, 7, 29, 0, 0, 0, tzinfo=timezone.utc),
+        "memo": "still valid",
+    }
+
+    coll = FakeInvoiceCollection([
+        old_expired,
+        recently_expired,
+        settled,
+        unsettled_but_settled_flag,
+        not_expired_yet,
+    ])
+
+    found = await find_expired_unsettled_invoices(
+        coll, as_of=as_of, retain_after_expiry=timedelta(days=1)
+    )
+    assert len(found) == 1
+    assert found[0]["r_hash"] == "old"
+
+
+@pytest.mark.asyncio
+async def test_find_expired_unsettled_invoices_respects_limit_and_sort():
+    as_of = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+    docs = [
+        {
+            "r_hash": "b",
+            "settle_index": 0,
+            "settled": False,
+            "expiry_date": datetime(2026, 7, 25, 0, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "r_hash": "a",
+            "settle_index": 0,
+            "settled": False,
+            "expiry_date": datetime(2026, 7, 24, 0, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "r_hash": "c",
+            "settle_index": 0,
+            "settled": False,
+            "expiry_date": datetime(2026, 7, 26, 0, 0, 0, tzinfo=timezone.utc),
+        },
+    ]
+    coll = FakeInvoiceCollection(docs)
+    found = await find_expired_unsettled_invoices(
+        coll, as_of=as_of, retain_after_expiry=timedelta(days=1), limit=2
+    )
+    assert len(found) == 2
+    # sorted by expiry_date ascending
+    assert found[0]["r_hash"] == "a"
+    assert found[1]["r_hash"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_delete_expired_unsettled_invoices():
+    as_of = datetime(2026, 7, 28, 12, 0, 0, tzinfo=timezone.utc)
+    coll = FakeInvoiceCollection([
+        {
+            "r_hash": "old",
+            "settle_index": 0,
+            "settled": False,
+            "expiry_date": datetime(2026, 7, 26, 0, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "r_hash": "recent",
+            "settle_index": 0,
+            "settled": False,
+            "expiry_date": datetime(2026, 7, 27, 18, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "r_hash": "paid",
+            "settle_index": 5,
+            "settled": True,
+            "expiry_date": datetime(2026, 7, 20, 0, 0, 0, tzinfo=timezone.utc),
+        },
+    ])
+
+    deleted = await delete_expired_unsettled_invoices(
+        coll, as_of=as_of, retain_after_expiry=timedelta(days=1)
+    )
+    assert deleted == 1
+    remaining = {d["r_hash"] for d in coll.docs}
+    assert remaining == {"recent", "paid"}
+
+    # Second pass should delete nothing more
+    deleted_again = await delete_expired_unsettled_invoices(
+        coll, as_of=as_of, retain_after_expiry=timedelta(days=1)
+    )
+    assert deleted_again == 0

--- a/tests/lnd_functions/test_lnd_index_floors.py
+++ b/tests/lnd_functions/test_lnd_index_floors.py
@@ -1,0 +1,64 @@
+"""Tests for optional LND index floors (start_add_index / start_payment_index)."""
+
+from lnd_monitor_v2 import (
+    LndIndexFloors,
+    apply_invoice_index_floors,
+    get_lnd_index_floors,
+    should_ignore_invoice_index,
+    should_ignore_payment_index,
+)
+from v4vapp_backend_v2.config.setup import InternalConfig
+
+
+def test_apply_invoice_index_floors_raises_to_config_floor():
+    floors = LndIndexFloors(add_index=100, settle_index=50)
+    assert apply_invoice_index_floors(10, 5, floors) == (100, 50)
+    assert apply_invoice_index_floors(200, 80, floors) == (200, 80)
+    assert apply_invoice_index_floors(None, None, floors) == (100, 50)
+
+
+def test_apply_invoice_index_floors_noop_when_zero():
+    floors = LndIndexFloors()
+    assert apply_invoice_index_floors(12, 3, floors) == (12, 3)
+    assert apply_invoice_index_floors(0, 0, floors) == (0, 0)
+
+
+def test_should_ignore_invoice_index_exclusive_floor():
+    floors = LndIndexFloors(add_index=10)
+    assert should_ignore_invoice_index(10, floors) is True
+    assert should_ignore_invoice_index(9, floors) is True
+    assert should_ignore_invoice_index(11, floors) is False
+    assert should_ignore_invoice_index(0, floors) is True
+    assert should_ignore_invoice_index(None, floors) is True
+
+
+def test_should_ignore_payment_index_exclusive_floor():
+    floors = LndIndexFloors(payment_index=5)
+    assert should_ignore_payment_index(5, floors) is True
+    assert should_ignore_payment_index(6, floors) is False
+    assert should_ignore_payment_index(1, floors) is True
+
+
+def test_should_ignore_noop_when_floor_unset():
+    floors = LndIndexFloors()
+    assert should_ignore_invoice_index(1, floors) is False
+    assert should_ignore_payment_index(1, floors) is False
+
+
+def test_get_lnd_index_floors_from_test_config():
+    """example2 in tests/data/config/config.yaml has floors set."""
+    InternalConfig(config_filename="config.yaml")
+    floors = get_lnd_index_floors("example2")
+    assert floors.add_index == 42
+    assert floors.payment_index == 7
+    # settle defaults to add when start_settle_index omitted
+    assert floors.settle_index == 42
+
+
+def test_get_lnd_index_floors_missing_fields_are_zero():
+    InternalConfig(config_filename="config.yaml")
+    floors = get_lnd_index_floors("example")
+    assert floors.add_index == 0
+    assert floors.settle_index == 0
+    assert floors.payment_index == 0
+    assert floors.has_any is False

--- a/uv.lock
+++ b/uv.lock
@@ -3773,7 +3773,7 @@ wheels = [
 
 [[package]]
 name = "v4vapp-backend-v2"
-version = "2.10.2"
+version = "2.10.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
Introduce optional index floors for LND sequences, allowing users to specify minimum values for add_index and payment_index. Implement invoice maintenance functions to manage expired unpaid invoices effectively. Update configuration and tests accordingly.