### PR TITLE
Refine invoice principal limit checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "v4vapp-backend-v2"
-version = "2.14.0"
+version = "2.14.1"
 description = "Back End for the V4V.app bridge from Hive to Lightning"
 authors = [{name = "Brian of London (home imac)", email = "brian@v4v.app"}]
 license = {text = "MIT"}

--- a/src/v4vapp_backend_v2/helpers/crypto_conversion.py
+++ b/src/v4vapp_backend_v2/helpers/crypto_conversion.py
@@ -299,7 +299,10 @@ class CryptoConv(BaseModel):
 
     def limit_test(self) -> bool:
         """
-        Check if the conversion is within the limits.
+        Check if this conversion's msats value falls within min/max invoice payment limits.
+
+        Prefer `limit_test(invoice_principal_msats)` when gating Hive→Lightning payments:
+        deposit conversions include fee headroom and must not be compared to invoice max.
 
         Returns:
             bool: True if the conversion is within limits, False otherwise.
@@ -315,7 +318,9 @@ class CryptoConv(BaseModel):
     @computed_field
     def in_limits(self) -> bool:
         """
-        Check if the conversion is within the limits.
+        Whether `self.msats` is within min/max invoice payment limits.
+
+        Not used to gate Hive→Lightning invoice payments (those use invoice principal).
 
         Returns:
             bool: True if the conversion is within limits, False otherwise.

--- a/src/v4vapp_backend_v2/helpers/service_fees.py
+++ b/src/v4vapp_backend_v2/helpers/service_fees.py
@@ -37,7 +37,7 @@ def calculate_fee_msats(msats: Decimal) -> Decimal:
     fee = ((config_data.conv_fee_percent + MARGIN_SPREAD) * msats) + (
         config_data.conv_fee_sats * 1_000
     )
-    return fee.quantize(Decimal("1"), rounding=ROUND_HALF_UP)  # Round to nearest integer
+    return fee.quantize(Decimal(1), rounding=ROUND_HALF_UP)  # Round to nearest integer
 
 
 def calculate_fee_estimate_msats(msats: Decimal) -> Decimal:
@@ -62,24 +62,31 @@ def calculate_fee_estimate_msats(msats: Decimal) -> Decimal:
     fee_estimate = Decimal(lnd_config.lightning_fee_base_msats) + (
         msats * Decimal(lnd_config.lightning_fee_estimate_ppm) / 1_000_000
     )
-    return fee_estimate.quantize(Decimal("1"), rounding=ROUND_HALF_UP)  # Round to nearest integer
+    return fee_estimate.quantize(Decimal(1), rounding=ROUND_HALF_UP)  # Round to nearest integer
 
 
-def limit_test(msats: Decimal = Decimal(0.0)) -> bool:
+def limit_test(msats: Decimal = Decimal(0)) -> bool:
     """
-    Checks if the given amount in millisatoshis (msats) is within the allowed invoice payment limits.
+    Checks if an invoice principal in millisatoshis is within configured payment limits.
 
-        msats (Decimal, optional): The amount in millisatoshis to check. Defaults to 0.0.
+    Callers must pass the Lightning invoice principal (BOLT11/LNURL `value_msat`, or the
+    amount attached to a zero-value invoice). Do not pass the full Hive/HBD deposit
+    conversion: deposits intentionally exceed principal to cover service and routing fees.
 
-        bool: True if the amount is within the configured minimum and maximum invoice payment limits.
+    Args:
+        msats: Invoice principal in millisatoshis.
+
+    Returns:
+        True if the principal is within min and max invoice payment limits.
+
     Raises:
         V4VMinimumInvoice: If the amount is less than the configured minimum invoice payment in satoshis.
         V4VMaximumInvoice: If the amount is greater than the configured maximum invoice payment in satoshis.
     """
     config_data = V4VConfig().data
     sats = Decimal(Decimal(msats) / Decimal(1000)).quantize(
-        Decimal("1"), rounding=ROUND_CEILING
-    )  # Convert msats to sats and round to nearest integer
+        Decimal(1), rounding=ROUND_CEILING
+    )  # Convert msats to sats; ceiling so fractional msats cannot slip under a limit
     if sats < config_data.minimum_invoice_payment_sats:
         raise V4VMinimumInvoice(
             f"{sats:,.0f} sats is below minimum invoice of {config_data.minimum_invoice_payment_sats:,.0f} sats"

--- a/src/v4vapp_backend_v2/process/process_transfer.py
+++ b/src/v4vapp_backend_v2/process/process_transfer.py
@@ -16,7 +16,11 @@ from v4vapp_backend_v2.conversion.hive_to_keepsats import conversion_hive_to_kee
 from v4vapp_backend_v2.conversion.keepsats_to_hive import conversion_keepsats_to_hive
 from v4vapp_backend_v2.helpers.currency_class import Currency
 from v4vapp_backend_v2.helpers.lightning_memo_class import LightningMemo
-from v4vapp_backend_v2.helpers.service_fees import V4VMaximumInvoice, V4VMinimumInvoice
+from v4vapp_backend_v2.helpers.service_fees import (
+    V4VMaximumInvoice,
+    V4VMinimumInvoice,
+    limit_test,
+)
 from v4vapp_backend_v2.hive.hive_extras import (
     HiveAccountNameOnExchangesList,
     HiveConversionLimits,
@@ -505,17 +509,29 @@ async def follow_on_transfer(
         await lnd_client.disconnect()
 
 
+def invoice_principal_msats(pay_req: PayReq, max_send_msats: Decimal) -> Decimal:
+    """
+    Amount used for min/max invoice payment limits.
+
+    Fixed-amount invoices: BOLT11 / LNURL invoice principal (`value_msat`).
+    Zero-value invoices: the amount we will attach/send (`max_send_msats`), which is
+    already net of service and estimated routing fees — not the Hive deposit conversion.
+    """
+    if pay_req.is_zero_value:
+        return Decimal(max_send_msats)
+    return Decimal(pay_req.value_msat)
+
+
 async def decode_incoming_and_checks(
     tracked_op: TrackedTransferWithCustomJson, lnd_client: LNDClient
 ) -> PayReq | None:
     """
     This asynchronous function processes a Lightning payment request contained in the `d_memo` field of a `TrackedTransfer` object.
     It performs the following steps:
-    - Logs the incoming payment request.
-    - Initializes the LND client using internal configuration.
     - Ensures conversion details are present; attempts to update them if missing.
     - Decodes the Lightning payment request and validates its structure.
-    - Checks conversion limits and user-specific payment limits.
+    - Checks min/max invoice limits against the invoice principal (not the Hive deposit).
+    - Checks amount-sent surplus / Keepsats balance and user rolling conversion limits.
     - Raises a `HiveTransferError` if any validation or decoding step fails.
 
     Args:
@@ -539,16 +555,6 @@ async def decode_incoming_and_checks(
             extra={"notification": False, **tracked_op.log_extra},
         )
         raise HiveTransferError("Conversion details not found for operation")
-
-    if not tracked_op.paywithsats:
-        try:
-            tracked_op.conv.limit_test()
-        except (V4VMinimumInvoice, V4VMaximumInvoice) as e:
-            logger.error(
-                f"Conversion limits exceeded for operation {tracked_op.short_id} {tracked_op.group_id_p}: {e}",
-                extra={"notification": False, **tracked_op.log_extra},
-            )
-            raise HiveTransferError(f"Conversion limits: {e}")
 
     try:
         max_send_msats = tracked_op.max_send_amount_msats()
@@ -589,7 +595,18 @@ async def decode_incoming_and_checks(
         )
         raise HiveTransferError(message)
 
-    # NOTE: this will not use the limit tests (maybe that is OK?) this is not a conversion operation
+    # Min/max invoice limits apply to Lightning principal only — not Hive deposit conversion
+    # (deposit must exceed principal to cover service + routing fees).
+    try:
+        principal_msats = invoice_principal_msats(pay_req, Decimal(max_send_msats))
+        limit_test(principal_msats)
+    except (V4VMinimumInvoice, V4VMaximumInvoice) as e:
+        logger.error(
+            f"Conversion limits exceeded for operation {tracked_op.short_id} {tracked_op.group_id_p}: {e}",
+            extra={"notification": False, **tracked_op.log_extra},
+        )
+        raise HiveTransferError(f"Conversion limits: {e}")
+
     if (
         tracked_op.paywithsats
     ):  # Custom Json operations are always paywithsats if they have a memo.
@@ -640,10 +657,9 @@ async def check_amount_sent(
             raise HiveTransferError("Conversion not set in operation.")
 
     if pay_req.is_zero_value:
-        if tracked_op.conv.in_limits:  # Computed field, treat like a property.
-            return ""
-        else:
-            return "Payment request has zero value, but conversion limits exceeded."
+        # Min/max invoice limits for zero-value invoices are enforced in
+        # decode_incoming_and_checks against max_send (principal), not deposit conv.
+        return ""
 
     surplus_msats = tracked_op.max_send_amount_msats() - pay_req.value_msat
     if surplus_msats < -5_000:  # Allow a 5 sat buffer for rounding errors (5,000 msats, 5 sats)

--- a/src/v4vapp_backend_v2/process/process_transfer.py
+++ b/src/v4vapp_backend_v2/process/process_transfer.py
@@ -602,10 +602,10 @@ async def decode_incoming_and_checks(
         limit_test(principal_msats)
     except (V4VMinimumInvoice, V4VMaximumInvoice) as e:
         logger.error(
-            f"Conversion limits exceeded for operation {tracked_op.short_id} {tracked_op.group_id_p}: {e}",
+            f"Lightning invoice principal limits exceeded for operation {tracked_op.short_id} {tracked_op.group_id_p}: {e}",
             extra={"notification": False, **tracked_op.log_extra},
         )
-        raise HiveTransferError(f"Conversion limits: {e}")
+        raise HiveTransferError(f"Invoice payment limits: {e}")
 
     if (
         tracked_op.paywithsats

--- a/tests/process/test_invoice_principal_limits.py
+++ b/tests/process/test_invoice_principal_limits.py
@@ -1,0 +1,62 @@
+"""Invoice min/max limits use Lightning principal, not Hive deposit conversion."""
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from v4vapp_backend_v2.helpers.service_fees import (
+    V4VMaximumInvoice,
+    V4VMinimumInvoice,
+    limit_test,
+)
+from v4vapp_backend_v2.process.process_transfer import invoice_principal_msats
+
+
+def test_invoice_principal_fixed_amount_uses_value_msat():
+    pay_req = MagicMock()
+    pay_req.is_zero_value = False
+    pay_req.value_msat = 174_195_000  # 174,195 sats — omztech-style invoice
+    max_send = Decimal(176_000_000)  # deposit net of fees, larger than principal
+    assert invoice_principal_msats(pay_req, max_send) == Decimal(174_195_000)
+
+
+def test_invoice_principal_zero_value_uses_max_send():
+    pay_req = MagicMock()
+    pay_req.is_zero_value = True
+    pay_req.value_msat = 0
+    max_send = Decimal(150_000_000)
+    assert invoice_principal_msats(pay_req, max_send) == Decimal(150_000_000)
+
+
+@patch("v4vapp_backend_v2.helpers.service_fees.V4VConfig")
+def test_omztech_style_deposit_would_fail_but_principal_passes(mock_v4v_config):
+    """
+    Regression: 117.201 HBD ≈ 181,726 sats deposit (with fee headroom) exceeded a
+    180k max when limits used deposit conv; invoice principal 174,195 sats is fine.
+    """
+    mock_v4v_config.return_value.data = SimpleNamespace(
+        minimum_invoice_payment_sats=Decimal(1),
+        maximum_invoice_payment_sats=Decimal(180_000),
+    )
+    deposit_msats = Decimal(181_726_000)
+    principal_msats = Decimal(174_195_000)
+
+    with pytest.raises(V4VMaximumInvoice):
+        limit_test(deposit_msats)
+
+    assert limit_test(principal_msats) is True
+
+
+@patch("v4vapp_backend_v2.helpers.service_fees.V4VConfig")
+def test_limit_test_still_rejects_oversized_principal(mock_v4v_config):
+    mock_v4v_config.return_value.data = SimpleNamespace(
+        minimum_invoice_payment_sats=Decimal(1_000),
+        maximum_invoice_payment_sats=Decimal(180_000),
+    )
+    with pytest.raises(V4VMaximumInvoice):
+        limit_test(Decimal(180_001_000))
+    with pytest.raises(V4VMinimumInvoice):
+        limit_test(Decimal(999_000))
+    assert limit_test(Decimal(180_000_000)) is True

--- a/uv.lock
+++ b/uv.lock
@@ -3918,7 +3918,7 @@ wheels = [
 
 [[package]]
 name = "v4vapp-backend-v2"
-version = "2.14.0"
+version = "2.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
Update limit checks to ensure they strictly apply to invoice principals rather than deposit conversions, enhancing validation for Lightning payments. Adjust related tests to reflect these changes.